### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Pull Requests
+
+**Feature branches**. We develop using the feature branches, see this section of the Git book:
+https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows.
+
+If you are a member of the development team, create a feature branch directly
+within the repository.
+
+Otherwise, if you are a non-member contributor, fork the repository and create
+the feature branch in your forked repository. See [this Github tuturial](
+https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
+) for more guidance. 
+
+**Branch Prefix**. Please prefix the branch with your Github user name 
+(*e.g.,* `mristin/Add-some-feature`).
+
+**Continuous Integration**. Github will run the continuous integration (CI) 
+automatically through Github actions to verify that the submitted changes are
+valid.
+
+## Commit Messages
+
+The commit messages follow the guidelines from 
+from https://chris.beams.io/posts/git-commit:
+* Separate subject from body with a blank line
+* Limit the subject line to 50 characters
+* Capitalize the subject line
+* Do not end the subject line with a period
+* Use the imperative mood in the subject line
+* Wrap the body at 72 characters
+* Use the body to explain *what* and *why* (instead of *how*)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ welcome! Please [submit a new issue](
 https://github.com/admin-shell-io/aasx-specification/issues/new
 ).
 
+If you want to contribute, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## License
 
 [![Creative Commons License](


### PR DESCRIPTION
This adds a bare CONTRIBUTING.md to guide the contributors on the form
of commit messages and hint about the continuous integration.