### PR TITLE
Upgrade commit message check to 1.0.6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the commit message(s)
-        uses: mristin/opinionated-commit-message@v1.0.5
+        uses: mristin/opinionated-commit-message@v1.0.6


### PR DESCRIPTION
This upgrades the version of opinionated-commit-message to 1.0.6
since we need to use the verb "rename" in the commit messages.