### PR TITLE
json: Fix type specifications (dataType -> type)

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -690,10 +690,10 @@
         {
           "properties": {
             "key": {
-              "dataType": "string"
+              "type": "string"
             },
             "value": {
-              "dataType": "string"
+              "type": "string"
             },
             "subjectId": {
               "$ref": "#/definitions/Reference"
@@ -861,7 +861,7 @@
               "$ref": "#/definitions/ModelingKind"
             },
             "idShort": {
-              "dataType": "string"
+              "type": "string"
             }
           },
           "required": [


### PR DESCRIPTION
The json schema previously specified the type of some attributes using
the dataType attribute, which is invalid and inconsistent to the other
type specifications.
This commit fixes this by renaming these dataType attributes to type.

I closed the previous PR because I didn't read the contributing guidelines in advance.