### PR TITLE
Add Release Section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 https://github.com/admin-shell-io/aas-specs/workflows/Check/badge.svg
 )](
 https://github.com/admin-shell-io/aas-specs/actions?query=workflow%3ACheck
-) 
+)
 [![Creative Commons License](
 https://i.creativecommons.org/l/by-nd/3.0/88x31.png
 )](
@@ -15,7 +15,7 @@ This repository provides the specifications of Asset Administration Shell.
 
 ## Schemas
 
-We provide schemas of the Asset Administration Shell for JSON, RFD and XML. 
+We provide schemas of the Asset Administration Shell for JSON, RFD and XML.
 These schemas are part of the document series, part 1,
 ["Details of the Asset Administration Shell"](
 https://www.plattform-i40.de/PI40/Redaktion/EN/Standardartikel/specification-administrationshell.html
@@ -23,7 +23,7 @@ https://www.plattform-i40.de/PI40/Redaktion/EN/Standardartikel/specification-adm
 
 ### JSON
 
-The JSON schema is available at 
+The JSON schema is available at
 [schemas/json/](schemas/json/) and follows JSON Schema version [2019-09](
 https://json-schema.org/specification-links.html#2019-09-formerly-known-as-draft-8
 ).
@@ -42,9 +42,17 @@ The XML schema is available at [schemas/xml/](schemas/xml/).
 
 The [XMI](https://de.wikipedia.org/wiki/XML_Metadata_Interchange) file for the [UML](https://de.wikipedia.org/wiki/Unified_Modeling_Language) metamodel [schemas/xmi](schemas/xmi/) ([XMI 2.1](https://www.omg.org/spec/XMI/2.1/About-XMI/))
 
+
+## Releases
+
+Currently, the following releases are available (see also the [releases](https://github.com/admin-shell-io/aas-specs/releases) section of this repository):
+* [3.0.1.RC01](https://github.com/admin-shell-io/aas-specs/releases/tag/v3.0.1.RC01) is a pre-release that solves a bug in the JSON schema of `3.0.RC01`
+* [3.0.RC01](https://github.com/admin-shell-io/aas-specs/releases/tag/v3.0.RC01) is a pre-release containing the schemes as contained by the document 'Details of the Asset Administration Shell - Part 1 - Version 3.0.RC01' [download](https://www.plattform-i40.de/PI40/Redaktion/EN/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.html)
+
+
 ## Contributing
 
-Feature requests, reports about inconsistencies, mistakes *etc.* are highly 
+Feature requests, reports about inconsistencies, mistakes *etc.* are highly
 welcome! Please [submit a new issue](
 https://github.com/admin-shell-io/aas-specs/issues/new
 ).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The [XMI](https://de.wikipedia.org/wiki/XML_Metadata_Interchange) file for the [
 ## Releases
 
 Currently, the following releases are available (see also the [releases](https://github.com/admin-shell-io/aas-specs/releases) section of this repository):
+* [3.0.2.RC01](https://github.com/admin-shell-io/aas-specs/releases/tag/v3.0.2.RC01) is a pre-release that solves several typos and bugs of `3.0.1.RC01`
 * [3.0.1.RC01](https://github.com/admin-shell-io/aas-specs/releases/tag/v3.0.1.RC01) is a pre-release that solves a bug in the JSON schema of `3.0.RC01`
 * [3.0.RC01](https://github.com/admin-shell-io/aas-specs/releases/tag/v3.0.RC01) is a pre-release containing the schemes as contained by the document 'Details of the Asset Administration Shell - Part 1 - Version 3.0.RC01' [download](https://www.plattform-i40.de/PI40/Redaktion/EN/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.html)
 


### PR DESCRIPTION
We have now several releases available. Unfortunetly, they are quite hard to find, especially for users who are not
that much experienced with GitHub. Now, we reader can directly find the releases in the README.