### PR TITLE
Typo in Word RDF in We provide schemas ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository provides the specifications of Asset Administration Shell.
 
 ## Schemas
 
-We provide schemas of the Asset Administration Shell for JSON, RFD and XML. 
+We provide schemas of the Asset Administration Shell for JSON, RDF and XML. 
 These schemas are part of the document series, part 1,
 ["Details of the Asset Administration Shell"](
 https://www.plattform-i40.de/PI40/Redaktion/EN/Standardartikel/specification-administrationshell.html


### PR DESCRIPTION
Changed "We provide schemas of the Asset Administration Shell for JSON, RFD and XML." to "We provide schemas of the Asset Administration Shell for JSON, RDF and XML."