### PR TITLE
Adapt examples according to JSON Schema 

### DIFF
--- a/schemas/json/examples/GlobalReference.json
+++ b/schemas/json/examples/GlobalReference.json
@@ -1,18 +1,62 @@
-{  "modelType":{
-    "name":"Property"
-},
-    "kind":"Instance",
-  "semanticId":{
-    "keys":[
-      {
-        "type":"GlobalReference",
-        "value":"0173-1#02-BAA120#007",
-        "idType":"IRDI"
+{
+  "assetAdministrationShells": [
+    {
+      "modelType": {
+        "name": "AssetAdministrationShell"
+      },
+      "idShort": "ExampleAAS",
+      "identification": {
+        "idType": "IRI",
+        "id": "http://customer.com/aas/7013_7091_9168_9175"
+      },
+      "assetInformation": {
+        "assetKind": "Instance",
+        "globalAssetId": {
+          "keys": [
+            {
+              "type": "Asset",
+              "value": "http://customer.com/assets/ZNVIAXJNAXQ0",
+              "idType": "IRI"
+            }
+          ]
+        }
       }
-    ]
-  },
-  "idShort":"MaxRotationSpeed",
-  "category":"PARAMETER",
-  "value":"560",
-  "valueType":"integer",
+    }
+  ],
+  "assets": [],
+  "submodels": [
+    {
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "idShort": "SubModelWithExternalRef",
+      "identification": {
+        "id": "http://env.com/submodels/ZNVJA29MZMJPCMDPDA",
+        "idType": "IRI"
+      },
+      "submodelElements": [
+        {
+          "modelType": {
+            "name": "Property"
+          },
+          "kind": "Instance",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "0173-1#02-BAA120#007",
+                "idType": "IRDI"
+              }
+            ]
+          },
+          "idShort": "ExternalRefToMaxRotationSpeed",
+          "category": "PARAMETER",
+          "value": "560",
+          "valueType": "integer"
+        }
+      ]
+    }
+  ],
+  "conceptDescriptions": []
 }

--- a/schemas/json/examples/ReferenceElement.json
+++ b/schemas/json/examples/ReferenceElement.json
@@ -1,31 +1,62 @@
 {
-  "modelType":{
-    "name":"ReferenceElement"
-  },
-  "kind":"Instance",
-  "semanticId":{
-    "keys":[
-      {
-        "type":"GlobalReference",
-        "value":"0173-1#02-BAA120#007",
-        "idType":"IRDI"
-      }
-    ]
-  },
-  "idShort":"MaxRotationSpeed",
-  "category":"PARAMETER",
-  "value":{
-    "keys":[
-      {
-        "idType":"IRI",
-        "type":"Submodel",
-        "value":"http://admin-shell.io/submodels/012"
+  "assetAdministrationShells": [
+    {
+      "modelType": {
+        "name": "AssetAdministrationShell"
       },
-      {
-        "idType":"IdShort",
-        "type":"Property",
-        "value":"MaxRotationSpeed"
+      "idShort": "ExampleAAS",
+      "identification": {
+        "idType": "IRI",
+        "id": "http://customer.com/aas/7013_7091_9168_9175"
+      },
+      "assetInformation": {
+        "assetKind": "Instance",
+        "globalAssetId": {
+          "keys": [
+            {
+              "type": "Asset",
+              "value": "http://customer.com/assets/ZNVIAXJNAXQ0",
+              "idType": "IRI"
+            }
+          ]
+        }
       }
-    ]
-  }
+    }
+  ],
+  "assets": [],
+  "submodels": [
+    {
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "idShort": "SubModelWithExternalRef",
+      "identification": {
+        "id": "http://env.com/submodels/ZNVJA29MZMJPCMDPDA",
+        "idType": "IRI"
+      },
+      "submodelElements": [
+        {
+          "modelType": {
+            "name": "Property"
+          },
+          "kind": "Instance",
+          "semanticId": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "0173-1#02-BAA120#007",
+                "idType": "IRDI"
+              }
+            ]
+          },
+          "idShort": "ExternalRefToMaxRotationSpeed",
+          "category": "PARAMETER",
+          "value": "560",
+          "valueType": "integer"
+        }
+      ]
+    }
+  ],
+  "conceptDescriptions": []
 }

--- a/schemas/json/examples/ReferencesJsonExample.json
+++ b/schemas/json/examples/ReferencesJsonExample.json
@@ -15,7 +15,10 @@
   "conceptDescriptions":[],
   "assetAdministrationShells":[
     {
-      "modelType":"AssetAdministrationShell",
+      "modelType":
+      {
+        "name":"AssetAdministrationShell"
+      },
       "submodels":[
         {
           "keys":[

--- a/schemas/json/examples/ReferencesJsonExample.json
+++ b/schemas/json/examples/ReferencesJsonExample.json
@@ -1,36 +1,53 @@
 {
-  "submodels":[
+  "assetAdministrationShells": [
     {
-      "modelType":{
-        "name":"Submodel"
+      "modelType": {
+        "name": "AssetAdministrationShell"
       },
-      "idShort":"S1",
-      "identification":{
-        "id":"http://env.com/submodels/S1",
-        "idType":"IRI"
+      "idShort": "ExampleAAS",
+      "identification": {
+        "idType": "IRI",
+        "id": "http://customer.com/aas/7013_7091_9168_9175"
       },
-      "submodelElements":[]
-    }
-  ],
-  "conceptDescriptions":[],
-  "assetAdministrationShells":[
-    {
-      "modelType":
-      {
-        "name":"AssetAdministrationShell"
-      },
-      "submodels":[
-        {
-          "keys":[
+      "assetInformation": {
+        "assetKind": "Instance",
+        "globalAssetId": {
+          "keys": [
             {
-              "idType":"IRI",
-              "type":"Submodel",
-              "value":"http://env.com/submodels/S1"
+              "type": "Asset",
+              "value": "http://customer.com/assets/ZNVIAXJNAXQ0",
+              "idType": "IRI"
+            }
+          ]
+        },
+      },
+      "submodels": [
+        {
+          "keys": [
+            {
+              "idType": "IRI",
+              "type": "Submodel",
+              "value": "http://env.com/submodels/S1"
             }
           ]
         }
       ]
     }
   ],
-  "assets":[]
+  "assets": [],
+  "submodels": [
+    {
+      "modelType": {
+        "name": "Submodel"
+      },
+      "kind": "Instance",
+      "idShort": "S1",
+      "identification": {
+        "id": "http://env.com/submodels/S1",
+        "idType": "IRI"
+      },
+      "submodelElements": []
+    }
+  ],
+  "conceptDescriptions": []
 }


### PR DESCRIPTION
This patch fixes #67, ReferenceElement.json and 
ReferencesJsonExample.json, according to JSON Schema.

In particular, it changes 
```
"modelType":"AssetAdministrationShell"
```
to
```
"modelType":{"name":"AssetAdministrationShell"}
```