### PR TITLE
Make continuous workflow run on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,11 @@
 name: Check
 
-on: push
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
 
 jobs:
   Execute:


### PR DESCRIPTION
The checks previously ran only on `push`, but not on other events. In
particular, the checks were not running on pull requests from non-team
members. This patch makes the checks run both on pushes as well as on
pull requests.