### PR TITLE
Reformat `CONTRIBUTING.md` for better readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,28 +2,26 @@
 
 ## Pull Requests
 
-**Feature branches**. We develop using the feature branches, see this section of the Git book:
-https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows.
+**Feature branches**.
+We develop using the feature branches, see [this section of the Git book].
 
-If you are a member of the development team, create a feature branch directly
-within the repository.
+[this section of the Git book]: https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows.
 
-Otherwise, if you are a non-member contributor, fork the repository and create
-the feature branch in your forked repository. See [this Github tuturial](
-https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
-) for more guidance. 
+If you are a member of the development team, create a feature branch directly within the repository.
 
-**Branch Prefix**. Please prefix the branch with your Github user name 
-(*e.g.,* `mristin/Add-some-feature`).
+Otherwise, if you are a non-member contributor, fork the repository and create the feature branch in your forked repository. See [this Github tutorial] for more guidance. 
 
-**Continuous Integration**. Github will run the continuous integration (CI) 
-automatically through Github actions to verify that the submitted changes are
-valid.
+[this Github tutorial]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
+
+**Branch Prefix**.
+Please prefix the branch with your Github user name (*e.g.,* `mristin/Add-some-feature`).
+
+**Continuous Integration**.
+Github will run the continuous integration (CI) automatically through Github actions to verify that the submitted changes are valid.
 
 ## Recommendation for Commit Messages
 
-The commit messages follow the guidelines from 
-from https://chris.beams.io/posts/git-commit:
+The commit messages follow the guidelines from https://chris.beams.io/posts/git-commit:
 * Separate subject from body with a blank line
 * Limit the subject line to 50 characters
 * Capitalize the subject line
@@ -34,9 +32,9 @@ from https://chris.beams.io/posts/git-commit:
 
 ## Pre-merge Checks
 
-We use the sample programs from 
-[schema-validation](https://github.com/admin-shell-io/schema-validation) 
-repository to validate the schemas against the example data.
+We use the sample programs from [schema-validation] repository to validate the schemas against the example data.
+
+[schema-validation]: https://github.com/admin-shell-io/schema-validation
 
 To install the schema-validation, invoke:
 
@@ -53,27 +51,45 @@ schemas\Validate.ps1
 ## Approval Process
 All changes must be reviewed and approved.
 
-Minor changes (simple failiures, typos, etc.) and additional content (more examples, etc.) can be accepted straight away after a brief review by the responsible reviewers.
+Minor changes (simple failures, typos, *etc.*) and additional content (more examples, etc.) can be accepted straight away after a brief review by the responsible reviewers.
 In order to indicate the change, the reviewers in charge must be added to the pull request.
+
 The responsible reviewers are:
 
 | Topic | Path | Reviewer |
-| ------------- | ------------- | ------------- |
-| JSON | [schemas/json/](schemas/json/) | [@Manu3756](https://github.com/Manu3756) @torben.deppe |
-| RDF | [schemas/rdf/](schemas/rdf/) | [@sebbader](https://github.com/sebbader) [@changqin26](https://github.com/changqin26) |
-| XML | [schemas/xml/](schemas/xml/) | [@JoergWende](https://github.com/JoergWende) [@Manu3756](https://github.com/Manu3756) |
-| XMI | [schemas/xmi/](schemas/xmi/) | [@BirgitBoss](https://github.com/BirgitBoss) |
-| aas-specs-repo | [aas-specs/](https://github.com/admin-shell-io/aas-specs) | [@BirgitBoss](https://github.com/BirgitBoss) [@mristin](https://github.com/mristin) |
+| -------------------- | --------------- | ------------------------- |
+| JSON                 | [schemas/json/] | [@Manu3756] @torben.deppe |
+| RDF                  | [schemas/rdf/]  | [@sebbader] [@changqin26] |
+| XML                  | [schemas/xml/]  | [@JoergWende] [@Manu3756] |
+| XMI                  | [schemas/xmi/]  | [@BirgitBoss]             |
+| aas-specs repository | [aas-specs/]    | [@BirgitBoss] [@mristin]  |
 
+[schemas/json/]: https://github.com/admin-shell-io/aas-specs/tree/master/schemas/json
+[schemas/rdf/]: https://github.com/admin-shell-io/aas-specs/tree/master/schemas/rdf
+[schemas/xml/]: https://github.com/admin-shell-io/aas-specs/tree/master/schemas/xml
+[schemas/xmi/]: https://github.com/admin-shell-io/aas-specs/tree/master/schemas/xmi
+[aas-specs/]: https://github.com/admin-shell-io/aas-specs
 
-Major changes must first be reviewed and approved by the joint working group of the [Platform Industrie 4.0](http://www.plattform-i40.de) and [IDTA](https://industrialdigitaltwin.org/).
+[@Manu3756]: https://github.com/Manu3756
+[@sebbader]: https://github.com/sebbader
+[@changqin26]: https://github.com/changqin26
+[@JoergWende]: https://github.com/JoergWende
+[@BirgitBoss]: https://github.com/BirgitBoss
+[@mristin]: https://github.com/mristin
 
+Major changes must first be reviewed and approved by the joint working group of the [Platform Industrie 4.0] and [IDTA].
+
+[Platform Industrie 4.0]: http://www.plattform-i40.de
+[IDTA]: https://industrialdigitaltwin.org/
 
 ## Merge into Master Branch
+
 After the approval the pull request can be merged into the repository.
 Therefore, an assignee with the ability to merge into the main brach has to be notified by adding it to the pull request.
 Those assignees are:
-- [@sebbader](https://github.com/sebbader)
-- [@mristin](https://github.com/mristin)
-- [@BirgitBoss](https://github.com/BirgitBoss) 
-- [@aorzelskiGH](https://github.com/aorzelskiGH) 
+- [@sebbader]
+- [@mristin]
+- [@BirgitBoss]
+- [@aorzelskiGH]
+
+[@aorzelskiGH]: https://github.com/aorzelskiGH


### PR DESCRIPTION
This patch does not change the content of the `CONTRIBUTING.md` but
merely reformats the markdown for better readability of the source code.

Namely:
* The URLs are extracted from the text and specified separately.
* The tables are formatted so that the columns are aligned (and
  readable in a text editor).
* All sentences are put on a single line ("unbroken") so that it is
  easier to diff changes in Git.