### PR TITLE
Document pre and post-merge steps in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,8 @@
 # Contributing
 
-## Pull Requests
+## Before the Pull Requests
 
-**Feature branches**.
-We develop using the feature branches, see [this section of the Git book].
+**Create Feature branches**. We develop using the feature branches, see [this section of the Git book].
 
 [this section of the Git book]: https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows.
 
@@ -16,9 +15,6 @@ Otherwise, if you are a non-member contributor, fork the repository and create t
 **Branch Prefix**.
 Please prefix the branch with your Github user name (*e.g.,* `mristin/Add-some-feature`).
 
-**Continuous Integration**.
-Github will run the continuous integration (CI) automatically through Github actions to verify that the submitted changes are valid.
-
 ## Recommendation for Commit Messages
 
 The commit messages follow the guidelines from https://chris.beams.io/posts/git-commit:
@@ -30,20 +26,22 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 * Wrap the body at 72 characters
 * Use the body to explain *what* and *why* (instead of *how*)
 
+## Create Pull Request
+After all changes have been made, a pull request has to be created. See [this Github tutorial] for more guidance. 
+
 ## Pre-Merge Checks
+**Continuous Integration**
+Github will run the continuous integration (CI) automatically through Github actions to verify that the submitted changes are valid. Every pull request automaticaly runs the continuous integration with every update.
 
-We use the sample programs from [schema-validation] repository to validate the schemas against the [JSON], [XML] and [RDF] examples in the aas-spec repository.
+The continuous integration must be **successfully completed** with `All checks have passed` before proceeding with the approval process.
 
-Every pull request automaticaly runs the schema-validation with every update.
-
-The schema-validation must be successfully completed with `All checks have passed` before proceeding with the approval process.
+We use the sample programs from [schema-validation] repository in the continuous integration to validate the schemas against the [JSON], [XML] and [RDF] examples from the aas-spec repository.
+It is posible to check the schema-validation before creating the pull request. 
 
 [schema-validation]: https://github.com/admin-shell-io/schema-validation
 [JSON]: /schemas/json/examples
 [XML]: /schemas/xml/examples
 [RDF]: /schemas/rdf/examples
-
-It is posible to check the schema-validation before creating the pull request. 
 
 First you need to install the schema-validation, invoke:
 
@@ -58,7 +56,7 @@ schemas\Validate.ps1
 ```
 
 ## Approval Process
-All changes must be reviewed and approved.
+All changes must be **reviewed** and **approved**.
 
 Minor changes (simple failures, typos, *etc.*) and additional content (more examples, etc.) can be accepted straight away after a brief review by the responsible reviewers.
 In order to indicate the change, the reviewers in charge must be added to the pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 * Wrap the body at 72 characters
 * Use the body to explain *what* and *why* (instead of *how*)
 
-## Pre-merge Checks
+## Pre-Merge Checks
 
 We use the sample programs from [schema-validation] repository to validate the schemas against the example data.
 
@@ -93,3 +93,10 @@ Those assignees are:
 - [@aorzelskiGH]
 
 [@aorzelskiGH]: https://github.com/aorzelskiGH
+
+## Post-Merge Cleanup
+Conratulaion. You sucessfully contributed to the aas-spec repository.
+
+If you are a member of the development team, pleas delete the feature branch directly you created within the repository.
+
+Otherwise, feel free to delete your forked ass-spec repository in your repositories.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ Github will run the continuous integration (CI) automatically through Github act
 
 The continuous integration must be **successfully completed** with `All checks have passed` before proceeding with the approval process.
 
+### Schema Validation
 We use the sample programs from [schema-validation] repository in the continuous integration to validate the schemas against the [JSON], [XML] and [RDF] examples from the aas-spec repository.
 It is possible, but not necessary to check the schema-validation without creating the pull request. 
 
@@ -64,6 +65,9 @@ Afterwards you run the script to validate the example data against the schemas b
 ```
 schemas\Validate.ps1
 ```
+
+### Check Commit and Pull Request Messages
+In accordance with `Recommendation for Commit Messages` the continuous integration checks the previously defined conditions. For the present development, however, this is not enforced.
 
 ## Approval Process
 All changes must be **reviewed** and **approved**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,23 +32,30 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 
 ## Pre-Merge Checks
 
-We use the sample programs from [schema-validation] repository to validate the schemas against the example data.
+We use the sample programs from [schema-validation] repository to validate the schemas against the [JSON], [XML] and [RDF] examples in the aas-spec repository.
+
+Every pull request automaticaly runs the schema-validation with every update.
+
+The schema-validation must be successfully completed with `All checks have passed` before proceeding with the approval process.
 
 [schema-validation]: https://github.com/admin-shell-io/schema-validation
+[JSON]: /schemas/json/examples
+[XML]: /schemas/xml/examples
+[RDF]: /schemas/rdf/examples
 
-To install the schema-validation, invoke:
+It is posible to check the schema-validation before creating the pull request. 
+
+First you need to install the schema-validation, invoke:
 
 ```
 schemas\InstallSchemaValidation.ps1
 ```
 
-To validate the example data against the schemas, call:
+Afterwards you run the script to validate the example data against the schemas by calling:
 
 ```
 schemas\Validate.ps1
 ```
-
-The schema-validation must be successfully completed before proceeding with the approval process.
 
 ## Approval Process
 All changes must be reviewed and approved.
@@ -99,6 +106,6 @@ Those assignees are:
 ## Post-Merge Cleanup
 Conratulaion. You sucessfully contributed to the aas-spec repository.
 
-If you are a member of the development team, pleas delete the feature branch directly you created within the repository.
+If you are a member of the development team, pleas delete the feature branch you directly created within the repository.
 
 Otherwise, feel free to delete your forked ass-spec repository in your repositories.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,20 @@
 # Contributing
 
+The specification of [Asset Administration Shell - Part 1] is an official publication of the joint working group of the [Platform Industrie 4.0] and [IDTA].
+The specification and schema definition, including application examples in the aas-spec repository must be particularly compliant with this.
+However, we invite the community to review and bugfix the specification and schema definition, including application examples. Therefore, we demand a defined procedure for the contribution in this document.
+
+[Asset Administration Shell - Part 1]: https://www.plattform-i40.de/PI40/Redaktion/EN/Standardartikel/specification-administrationshell.html
+
 ## Before the Pull Requests
 
 **Create Feature branches**. We develop using the feature branches, see [this section of the Git book].
 
 [this section of the Git book]: https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows.
 
-If you are a member of the development team, create a feature branch directly within the repository.
+If you are a member of the development team, [create a feature branch] directly within the repository.
+
+[create a feature branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository
 
 Otherwise, if you are a non-member contributor, fork the repository and create the feature branch in your forked repository. See [this Github tutorial] for more guidance. 
 
@@ -27,7 +35,9 @@ The commit messages follow the guidelines from https://chris.beams.io/posts/git-
 * Use the body to explain *what* and *why* (instead of *how*)
 
 ## Create Pull Request
-After all changes have been made, a pull request has to be created. See [this Github tutorial] for more guidance. 
+After all changes have been comitted to your feature branch, a [pull request] has to be created. See [this Github tutorial] for more guidance. 
+
+[pull request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 
 ## Pre-Merge Checks
 **Continuous Integration**
@@ -36,7 +46,7 @@ Github will run the continuous integration (CI) automatically through Github act
 The continuous integration must be **successfully completed** with `All checks have passed` before proceeding with the approval process.
 
 We use the sample programs from [schema-validation] repository in the continuous integration to validate the schemas against the [JSON], [XML] and [RDF] examples from the aas-spec repository.
-It is posible to check the schema-validation before creating the pull request. 
+It is possible, but not necessary to check the schema-validation without creating the pull request. 
 
 [schema-validation]: https://github.com/admin-shell-io/schema-validation
 [JSON]: /schemas/json/examples
@@ -102,8 +112,8 @@ Those assignees are:
 [@aorzelskiGH]: https://github.com/aorzelskiGH
 
 ## Post-Merge Cleanup
-Conratulaion. You sucessfully contributed to the aas-spec repository.
+**Conratulaion.** You sucessfully contributed to the aas-spec repository.
 
-If you are a member of the development team, pleas delete the feature branch you directly created within the repository.
+If you are a member of the development team, pleas delete the feature branch you directly created within the aas-specs repository.
 
 Otherwise, feel free to delete your forked ass-spec repository in your repositories.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ To validate the example data against the schemas, call:
 schemas\Validate.ps1
 ```
 
+The schema-validation must be successfully completed before proceeding with the approval process.
+
 ## Approval Process
 All changes must be reviewed and approved.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The specification of [Asset Administration Shell - Part 1] is an official publication of the joint working group of the [Platform Industrie 4.0] and [IDTA].
 The specification and schema definition, including application examples in the aas-spec repository must be particularly compliant with this.
-However, we invite the community to review and bugfix the specification and schema definition, including application examples. Therefore, we demand a defined procedure for the contribution in this document.
+However, we invite the community to review, report and bugfix the specification and schema definition, including application examples. Therefore, we demand a defined procedure for the contribution in this repository.
 
 [Asset Administration Shell - Part 1]: https://www.plattform-i40.de/PI40/Redaktion/EN/Standardartikel/specification-administrationshell.html
 


### PR DESCRIPTION
In this patch, we document what steps need to be undertaken before and
after a merge.

In particular, we highlight that branches need to be deleted since
lingering branches are confusing for the developers and prevent
various cache clean-ups in Git.