### PR TITLE
Change Reviewers in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,11 @@ The responsible reviewers are:
 
 | Topic | Path | Reviewer |
 | -------------------- | --------------- | ------------------------- |
-| JSON                 | [schemas/json/] | [@Manu3756] @torben.deppe |
-| RDF                  | [schemas/rdf/]  | [@sebbader] [@changqin26] |
-| XML                  | [schemas/xml/]  | [@JoergWende] [@Manu3756] |
+| JSON                 | [schemas/json/] | [@Manu3756] [@TorbenD] [@mristin] |
+| RDF                  | [schemas/rdf/]  | [@sebbader] [@changqin26] [@mristin] |
+| XML                  | [schemas/xml/]  | [@JoergWende] [@Manu3756] [@mristin] |
 | XMI                  | [schemas/xmi/]  | [@BirgitBoss]             |
-| aas-specs repository | [aas-specs/]    | [@BirgitBoss] [@mristin]  |
+| aas-specs repository | [aas-specs/]    | [@BirgitBoss] [@mristin] |
 
 [schemas/json/]: https://github.com/admin-shell-io/aas-specs/tree/master/schemas/json
 [schemas/rdf/]: https://github.com/admin-shell-io/aas-specs/tree/master/schemas/rdf
@@ -96,11 +96,13 @@ The responsible reviewers are:
 [aas-specs/]: https://github.com/admin-shell-io/aas-specs
 
 [@Manu3756]: https://github.com/Manu3756
+[@TorbenD]:https://github.com/torbend
 [@sebbader]: https://github.com/sebbader
 [@changqin26]: https://github.com/changqin26
 [@JoergWende]: https://github.com/JoergWende
 [@BirgitBoss]: https://github.com/BirgitBoss
 [@mristin]: https://github.com/mristin
+[@g1zzm0]:https://github.com/g1zzm0
 
 Major changes must first be reviewed and approved by the joint working group of the [Platform Industrie 4.0] and [IDTA].
 


### PR DESCRIPTION
Previously, we missed to list a couple of reviewers in
`CONTRIBUTING.md`. In this patch, we fix the omissions:
* @mristin is added as a reviewer for the XML, JSON and RDF schemas
  because we will start to use the schema generator [aas-core-codegen]
  at some point, and
* We list Torben Miny with his correct GitHub user name (`@TorbenD`)
  since the current user name is used in GitLab.
  
[aas-core-codegen]: https://github.com/aas-core-works/aas-core-codegen
  
review-requested: @mristin