### PR TITLE
Add back checking on commit messages

### DIFF
--- a/.github/workflows/check-schemas-and-examples.yml
+++ b/.github/workflows/check-schemas-and-examples.yml
@@ -1,4 +1,4 @@
-name: Check
+name: Check-schemas-and-examples
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
     branches: [ "**" ]
 
 jobs:
-  Execute:
+  Check-schemas-and-examples:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-title-and-description-of-pull-request.yml
+++ b/.github/workflows/check-title-and-description-of-pull-request.yml
@@ -1,0 +1,25 @@
+name: Check-title-and-description-of-pull-request
+
+on: 
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  Check-title-and-description-of-pull-request:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Check the title and description of the pull request
+        uses: mristin/opinionated-commit-message@v2.3.2
+
+      - name: READ HERE ON FAILURE FOR MORE INSTRUCTIONS
+        if: ${{ failure() }}
+        run: |
+          Write-Host (
+            "The title and the description of your pull request do not fit our style guide. " +
+            "Please inspect carefully the error messages above and edit the pull request. " +
+            "Since we are always squashing before merge, you can leave the commit messages as-are.`n`n" +
+            "See the following page for more information about the style of the commit messages: " +
+            "https://github.com/admin-shell-io/aas-specs/blob/master/CONTRIBUTING.md#recommendation-for-commit-messages"
+          )


### PR DESCRIPTION
This patch re-introduced the checks on commit messages in order to make
the git log more uniform and thus easier to read and follow.

Originally, we turned off the check of commit messages in
2ec5d79b71de83be9fb364c39df66a5cb5a61569. Many people were confused with
the uninformative error messages whenever the style check did not pass.
We hope that this change provides a better error description and finds
more frequent adoption.

We also rename the existing CI workflow to clarify the distinction.