### PR TITLE
Change order in JSON schema

### DIFF
--- a/schemas/json/.gitignore
+++ b/schemas/json/.gitignore
@@ -1,0 +1,2 @@
+reformat.py
+aas.new.json

--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -36,97 +36,11 @@
     }
   },
   "definitions": {
-    "Referable": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/HasExtensions"
-        },
-        {
-          "properties": {
-            "idShort": {
-              "type": "string"
-            },
-            "category": {
-              "type": "string"
-            },
-            "displayName": {
-              "type": "string"
-            },
-            "description": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
-            },
-            "modelType": {
-              "$ref": "#/definitions/ModelType"
-            }
-          },
-          "required": [
-            "modelType",
-            "idShort"
-          ]
-        }
-      ]
-    },
-    "Identifiable": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Referable"
-        },
-        {
-          "properties": {
-            "identification": {
-              "$ref": "#/definitions/Identifier"
-            },
-            "administration": {
-              "$ref": "#/definitions/AdministrativeInformation"
-            }
-          },
-          "required": [
-            "identification"
-          ]
-        }
-      ]
-    },
-    "Qualifiable": {
-      "type": "object",
-      "properties": {
-        "qualifiers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Constraint"
-          }
-        }
-      }
-    },
     "HasSemantics": {
       "type": "object",
       "properties": {
         "semanticId": {
           "$ref": "#/definitions/Reference"
-        }
-      }
-    },
-    "HasDataSpecification": {
-      "type": "object",
-      "properties": {
-        "embeddedDataSpecifications": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/EmbeddedDataSpecification"
-          }
-        }
-      }
-    },
-    "HasExtensions": {
-      "type": "object",
-      "properties": {
-        "extensions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Extension"
-          }
         }
       }
     },
@@ -202,6 +116,176 @@
         }
       ]
     },
+    "HasExtensions": {
+      "type": "object",
+      "properties": {
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
+        }
+      }
+    },
+    "Referable": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/HasExtensions"
+        },
+        {
+          "properties": {
+            "idShort": {
+              "type": "string"
+            },
+            "displayName": {
+              "type": "string"
+            },
+            "category": {
+              "type": "string"
+            },
+            "description": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LangString"
+              }
+            },
+            "modelType": {
+              "$ref": "#/definitions/ModelType"
+            }
+          },
+          "required": [
+            "idShort",
+            "modelType"
+          ]
+        }
+      ]
+    },
+    "Identifiable": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Referable"
+        },
+        {
+          "properties": {
+            "administration": {
+              "$ref": "#/definitions/AdministrativeInformation"
+            },
+            "identification": {
+              "$ref": "#/definitions/Identifier"
+            }
+          },
+          "required": [
+            "identification"
+          ]
+        }
+      ]
+    },
+    "Identifier": {
+      "type": "object",
+      "properties": {
+        "idType": {
+          "$ref": "#/definitions/KeyType"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "idType",
+        "id"
+      ]
+    },
+    "ModelingKind": {
+      "type": "string",
+      "enum": [
+        "Template",
+        "Instance"
+      ]
+    },
+    "HasDataSpecification": {
+      "type": "object",
+      "properties": {
+        "embeddedDataSpecifications": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EmbeddedDataSpecification"
+          }
+        }
+      }
+    },
+    "AdministrativeInformation": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "string"
+        }
+      }
+    },
+    "Qualifiable": {
+      "type": "object",
+      "properties": {
+        "qualifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        }
+      }
+    },
+    "Constraint": {
+      "type": "object",
+      "properties": {
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
+        }
+      },
+      "required": [
+        "modelType"
+      ]
+    },
+    "Qualifier": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Constraint"
+        },
+        {
+          "$ref": "#/definitions/HasSemantics"
+        },
+        {
+          "$ref": "#/definitions/ValueObject"
+        },
+        {
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        }
+      ]
+    },
+    "Formula": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Constraint"
+        },
+        {
+          "properties": {
+            "dependsOn": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Reference"
+              }
+            }
+          }
+        }
+      ]
+    },
     "AssetAdministrationShell": {
       "allOf": [
         {
@@ -214,6 +298,9 @@
           "properties": {
             "derivedFrom": {
               "$ref": "#/definitions/Reference"
+            },
+            "security": {
+              "$ref": "#/definitions/Security"
             },
             "assetInformation": {
               "$ref": "#/definitions/AssetInformation"
@@ -229,9 +316,6 @@
               "items": {
                 "$ref": "#/definitions/View"
               }
-            },
-            "security": {
-              "$ref": "#/definitions/Security"
             }
           },
           "required": [
@@ -239,406 +323,6 @@
           ]
         }
       ]
-    },
-    "Identifier": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "idType": {
-          "$ref": "#/definitions/KeyType"
-        }
-      },
-      "required": [
-        "id",
-        "idType"
-      ]
-    },
-    "KeyType": {
-      "type": "string",
-      "enum": [
-        "Custom",
-        "IRDI",
-        "IRI",
-        "IdShort",
-        "FragmentId"
-      ]
-    },
-    "AdministrativeInformation": {
-      "type": "object",
-      "properties": {
-        "version": {
-          "type": "string"
-        },
-        "revision": {
-          "type": "string"
-        }
-      }
-    },
-    "LangString": {
-      "type": "object",
-      "properties": {
-        "language": {
-          "type": "string"
-        },
-        "text": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "language",
-        "text"
-      ]
-    },
-    "Reference": {
-      "type": "object",
-      "properties": {
-        "keys": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Key"
-          }
-        }
-      },
-      "required": [
-        "keys"
-      ]
-    },
-    "Key": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/KeyElements"
-        },
-        "idType": {
-          "$ref": "#/definitions/KeyType"
-        },
-        "value": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "idType",
-        "value"
-      ]
-    },
-    "KeyElements": {
-      "type": "string",
-      "enum": [
-        "Asset",
-        "AssetAdministrationShell",
-        "ConceptDescription",
-        "Submodel",
-        "AccessPermissionRule",
-        "AnnotatedRelationshipElement",
-        "BasicEvent",
-        "Blob",
-        "Capability",
-        "DataElement",
-        "File",
-        "Entity",
-        "Event",
-        "MultiLanguageProperty",
-        "Operation",
-        "Property",
-        "Range",
-        "ReferenceElement",
-        "RelationshipElement",
-        "SubmodelElement",
-        "SubmodelElementCollection",
-        "View",
-        "GlobalReference",
-        "FragmentReference"
-      ]
-    },
-    "ModelTypes": {
-      "type": "string",
-      "enum": [
-        "Asset",
-        "AssetAdministrationShell",
-        "ConceptDescription",
-        "Submodel",
-        "AccessPermissionRule",
-        "AnnotatedRelationshipElement",
-        "BasicEvent",
-        "Blob",
-        "Capability",
-        "DataElement",
-        "File",
-        "Entity",
-        "Event",
-        "MultiLanguageProperty",
-        "Operation",
-        "Property",
-        "Range",
-        "ReferenceElement",
-        "RelationshipElement",
-        "SubmodelElement",
-        "SubmodelElementCollection",
-        "View",
-        "GlobalReference",
-        "FragmentReference",
-        "Constraint",
-        "Formula",
-        "Qualifier"
-      ]
-    },
-    "ModelType": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "$ref": "#/definitions/ModelTypes"
-        }
-      },
-      "required": [
-        "name"
-      ]
-    },
-    "EmbeddedDataSpecification": {
-      "type": "object",
-      "properties": {
-        "dataSpecification": {
-          "$ref": "#/definitions/Reference"
-        },
-        "dataSpecificationContent": {
-          "$ref": "#/definitions/DataSpecificationContent"
-        }
-      },
-      "required": [
-        "dataSpecification",
-        "dataSpecificationContent"
-      ]
-    },
-    "DataSpecificationContent": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/DataSpecificationIEC61360Content"
-        },
-        {
-          "$ref": "#/definitions/DataSpecificationPhysicalUnitContent"
-        }
-      ]
-    },
-    "DataSpecificationPhysicalUnitContent": {
-      "type": "object",
-      "properties": {
-        "unitName": {
-          "type": "string"
-        },
-        "unitSymbol": {
-          "type": "string"
-        },
-        "definition": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/LangString"
-          }
-        },
-        "siNotation": {
-          "type": "string"
-        },
-        "siName": {
-          "type": "string"
-        },
-        "dinNotation": {
-          "type": "string"
-        },
-        "eceName": {
-          "type": "string"
-        },
-        "eceCode": {
-          "type": "string"
-        },
-        "nistName": {
-          "type": "string"
-        },
-        "sourceOfDefinition": {
-          "type": "string"
-        },
-        "conversionFactor": {
-          "type": "string"
-        },
-        "registrationAuthorityId": {
-          "type": "string"
-        },
-        "supplier": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "unitName",
-        "unitSymbol",
-        "definition"
-      ]
-    },
-    "DataSpecificationIEC61360Content": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/ValueObject"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "dataType": {
-              "enum": [
-                "DATE",
-                "STRING",
-                "STRING_TRANSLATABLE",
-                "REAL_MEASURE",
-                "REAL_COUNT",
-                "REAL_CURRENCY",
-                "BOOLEAN",
-                "URL",
-                "RATIONAL",
-                "RATIONAL_MEASURE",
-                "TIME",
-                "TIMESTAMP",
-                "INTEGER_COUNT",
-                "INTEGER_MEASURE",
-                "INTEGER_CURRENCY"
-              ]
-            },
-            "definition": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
-            },
-            "preferredName": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
-            },
-            "shortName": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
-            },
-            "sourceOfDefinition": {
-              "type": "string"
-            },
-            "symbol": {
-              "type": "string"
-            },
-            "unit": {
-              "type": "string"
-            },
-            "unitId": {
-              "$ref": "#/definitions/Reference"
-            },
-            "valueFormat": {
-              "type": "string"
-            },
-            "valueList": {
-              "$ref": "#/definitions/ValueList"
-            },
-            "levelType": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LevelType"
-              }
-            }
-          },
-          "required": [
-            "preferredName"
-          ]
-        }
-      ]
-    },
-    "LevelType": {
-      "type": "string",
-      "enum": [
-        "Min",
-        "Max",
-        "Nom",
-        "Typ"
-      ]
-    },
-    "ValueList": {
-      "type": "object",
-      "properties": {
-        "valueReferencePairTypes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/definitions/ValueReferencePairType"
-          }
-        }
-      },
-      "required": [
-        "valueReferencePairTypes"
-      ]
-    },
-    "ValueReferencePairType": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/ValueObject"
-        }
-      ]
-    },
-    "ValueObject": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "string"
-        },
-        "valueId": {
-          "$ref": "#/definitions/Reference"
-        },
-        "valueType": {
-          "type": "string",
-          "enum": [
-            "anyUri",
-            "base64Binary",
-            "boolean",
-            "date",
-            "dateTime",
-            "dateTimeStamp",
-            "decimal",
-            "integer",
-            "long",
-            "int",
-            "short",
-            "byte",
-            "nonNegativeInteger",
-            "positiveInteger",
-            "unsignedLong",
-            "unsignedInt",
-            "unsignedShort",
-            "unsignedByte",
-            "nonPositiveInteger",
-            "negativeInteger",
-            "double",
-            "duration",
-            "dayTimeDuration",
-            "yearMonthDuration",
-            "float",
-            "gDay",
-            "gMonth",
-            "gMonthDay",
-            "gYear",
-            "gYearMonth",
-            "hexBinary",
-            "NOTATION",
-            "QName",
-            "string",
-            "normalizedString",
-            "token",
-            "language",
-            "Name",
-            "NCName",
-            "ENTITY",
-            "ID",
-            "IDREF",
-            "NMTOKEN",
-            "time"
-          ]
-        }
-      }
     },
     "Asset": {
       "allOf": [
@@ -682,6 +366,13 @@
         }
       ]
     },
+    "AssetKind": {
+      "type": "string",
+      "enum": [
+        "Type",
+        "Instance"
+      ]
+    },
     "IdentifierKeyValuePair": {
       "allOf": [
         {
@@ -705,20 +396,6 @@
             "subjectId"
           ]
         }
-      ]
-    },
-    "AssetKind": {
-      "type": "string",
-      "enum": [
-        "Type",
-        "Instance"
-      ]
-    },
-    "ModelingKind": {
-      "type": "string",
-      "enum": [
-        "Template",
-        "Instance"
       ]
     },
     "Submodel": {
@@ -750,15 +427,366 @@
         }
       ]
     },
-    "Constraint": {
-      "type": "object",
-      "properties": {
-        "modelType": {
-          "$ref": "#/definitions/ModelType"
+    "SubmodelElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Referable"
+        },
+        {
+          "$ref": "#/definitions/HasDataSpecification"
+        },
+        {
+          "$ref": "#/definitions/HasSemantics"
+        },
+        {
+          "$ref": "#/definitions/Qualifiable"
+        },
+        {
+          "properties": {
+            "kind": {
+              "$ref": "#/definitions/ModelingKind"
+            },
+            "idShort": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "idShort"
+          ]
         }
-      },
-      "required": [
-        "modelType"
+      ]
+    },
+    "RelationshipElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "first": {
+              "$ref": "#/definitions/Reference"
+            },
+            "second": {
+              "$ref": "#/definitions/Reference"
+            }
+          },
+          "required": [
+            "first",
+            "second"
+          ]
+        }
+      ]
+    },
+    "SubmodelElementCollection": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "value": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/Blob"
+                  },
+                  {
+                    "$ref": "#/definitions/File"
+                  },
+                  {
+                    "$ref": "#/definitions/Capability"
+                  },
+                  {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  {
+                    "$ref": "#/definitions/Event"
+                  },
+                  {
+                    "$ref": "#/definitions/BasicEvent"
+                  },
+                  {
+                    "$ref": "#/definitions/MultiLanguageProperty"
+                  },
+                  {
+                    "$ref": "#/definitions/Operation"
+                  },
+                  {
+                    "$ref": "#/definitions/Property"
+                  },
+                  {
+                    "$ref": "#/definitions/Range"
+                  },
+                  {
+                    "$ref": "#/definitions/ReferenceElement"
+                  },
+                  {
+                    "$ref": "#/definitions/RelationshipElement"
+                  },
+                  {
+                    "$ref": "#/definitions/SubmodelElementCollection"
+                  }
+                ]
+              }
+            },
+            "allowDuplicates": {
+              "type": "boolean"
+            },
+            "ordered": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "Property": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "$ref": "#/definitions/ValueObject"
+        }
+      ]
+    },
+    "MultiLanguageProperty": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LangString"
+              }
+            },
+            "valueId": {
+              "$ref": "#/definitions/Reference"
+            }
+          }
+        }
+      ]
+    },
+    "Range": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "valueType": {
+              "type": "string",
+              "enum": [
+                "anyUri",
+                "base64Binary",
+                "boolean",
+                "date",
+                "dateTime",
+                "dateTimeStamp",
+                "decimal",
+                "integer",
+                "long",
+                "int",
+                "short",
+                "byte",
+                "nonNegativeInteger",
+                "positiveInteger",
+                "unsignedLong",
+                "unsignedInt",
+                "unsignedShort",
+                "unsignedByte",
+                "nonPositiveInteger",
+                "negativeInteger",
+                "double",
+                "duration",
+                "dayTimeDuration",
+                "yearMonthDuration",
+                "float",
+                "gDay",
+                "gMonth",
+                "gMonthDay",
+                "gYear",
+                "gYearMonth",
+                "hexBinary",
+                "NOTATION",
+                "QName",
+                "string",
+                "normalizedString",
+                "token",
+                "language",
+                "Name",
+                "NCName",
+                "ENTITY",
+                "ID",
+                "IDREF",
+                "NMTOKEN",
+                "time"
+              ]
+            },
+            "min": {
+              "type": "string"
+            },
+            "max": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "valueType"
+          ]
+        }
+      ]
+    },
+    "ReferenceElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "value": {
+              "$ref": "#/definitions/Reference"
+            }
+          }
+        }
+      ]
+    },
+    "Blob": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "mimeType": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "mimeType"
+          ]
+        }
+      ]
+    },
+    "File": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "mimeType": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "mimeType"
+          ]
+        }
+      ]
+    },
+    "AnnotatedRelationshipElement": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RelationshipElement"
+        },
+        {
+          "properties": {
+            "annotation": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/Blob"
+                  },
+                  {
+                    "$ref": "#/definitions/File"
+                  },
+                  {
+                    "$ref": "#/definitions/MultiLanguageProperty"
+                  },
+                  {
+                    "$ref": "#/definitions/Property"
+                  },
+                  {
+                    "$ref": "#/definitions/Range"
+                  },
+                  {
+                    "$ref": "#/definitions/ReferenceElement"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "EntityType": {
+      "type": "string",
+      "enum": [
+        "CoManagedEntity",
+        "SelfManagedEntity"
+      ]
+    },
+    "Entity": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "entityType": {
+              "$ref": "#/definitions/EntityType"
+            },
+            "statements": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SubmodelElement"
+              }
+            },
+            "globalAssetId": {
+              "$ref": "#/definitions/Reference"
+            },
+            "specificAssetIds": {
+              "$ref": "#/definitions/IdentifierKeyValuePair"
+            }
+          },
+          "required": [
+            "entityType"
+          ]
+        }
+      ]
+    },
+    "Event": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        }
+      ]
+    },
+    "BasicEvent": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Event"
+        },
+        {
+          "properties": {
+            "observed": {
+              "$ref": "#/definitions/Reference"
+            }
+          },
+          "required": [
+            "observed"
+          ]
+        }
       ]
     },
     "Operation": {
@@ -841,115 +869,10 @@
         "value"
       ]
     },
-    "SubmodelElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Referable"
-        },
-        {
-          "$ref": "#/definitions/HasDataSpecification"
-        },
-        {
-          "$ref": "#/definitions/HasSemantics"
-        },
-        {
-          "$ref": "#/definitions/Qualifiable"
-        },
-        {
-          "properties": {
-            "kind": {
-              "$ref": "#/definitions/ModelingKind"
-            },
-            "idShort": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "idShort"
-          ]
-        }
-      ]
-    },
-    "Event": {
+    "Capability": {
       "allOf": [
         {
           "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
-    },
-    "BasicEvent": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Event"
-        },
-        {
-          "properties": {
-            "observed": {
-              "$ref": "#/definitions/Reference"
-            }
-          },
-          "required": [
-            "observed"
-          ]
-        }
-      ]
-    },
-    "EntityType": {
-      "type": "string",
-      "enum": [
-        "CoManagedEntity",
-        "SelfManagedEntity"
-      ]
-    },
-    "Entity": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "statements": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SubmodelElement"
-              }
-            },
-            "entityType": {
-              "$ref": "#/definitions/EntityType"
-            },
-            "globalAssetId": {
-              "$ref": "#/definitions/Reference"
-            },
-            "specificAssetIds": {
-              "$ref": "#/definitions/IdentifierKeyValuePair"
-            }
-          },
-          "required": [
-            "entityType"
-          ]
-        }
-      ]
-    },
-    "View": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Referable"
-        },
-        {
-          "$ref": "#/definitions/HasDataSpecification"
-        },
-        {
-          "$ref": "#/definitions/HasSemantics"
-        },
-        {
-          "properties": {
-            "containedElements": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Reference"
-              }
-            }
-          }
         }
       ]
     },
@@ -973,317 +896,20 @@
         }
       ]
     },
-    "Capability": {
+    "View": {
       "allOf": [
         {
-          "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
-    },
-    "Property": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "$ref": "#/definitions/ValueObject"
-        }
-      ]
-    },
-    "Range": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "valueType": {
-              "type": "string",
-              "enum": [
-                "anyUri",
-                "base64Binary",
-                "boolean",
-                "date",
-                "dateTime",
-                "dateTimeStamp",
-                "decimal",
-                "integer",
-                "long",
-                "int",
-                "short",
-                "byte",
-                "nonNegativeInteger",
-                "positiveInteger",
-                "unsignedLong",
-                "unsignedInt",
-                "unsignedShort",
-                "unsignedByte",
-                "nonPositiveInteger",
-                "negativeInteger",
-                "double",
-                "duration",
-                "dayTimeDuration",
-                "yearMonthDuration",
-                "float",
-                "gDay",
-                "gMonth",
-                "gMonthDay",
-                "gYear",
-                "gYearMonth",
-                "hexBinary",
-                "NOTATION",
-                "QName",
-                "string",
-                "normalizedString",
-                "token",
-                "language",
-                "Name",
-                "NCName",
-                "ENTITY",
-                "ID",
-                "IDREF",
-                "NMTOKEN",
-                "time"
-              ]
-            },
-            "min": {
-              "type": "string"
-            },
-            "max": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "valueType"
-          ]
-        }
-      ]
-    },
-    "MultiLanguageProperty": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "value": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
-            },
-            "valueId": {
-              "$ref": "#/definitions/Reference"
-            }
-          }
-        }
-      ]
-    },
-    "File": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "value": {
-              "type": "string"
-            },
-            "mimeType": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "mimeType"
-          ]
-        }
-      ]
-    },
-    "Blob": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "value": {
-              "type": "string"
-            },
-            "mimeType": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "mimeType"
-          ]
-        }
-      ]
-    },
-    "ReferenceElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "value": {
-              "$ref": "#/definitions/Reference"
-            }
-          }
-        }
-      ]
-    },
-    "SubmodelElementCollection": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "value": {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/definitions/Blob"
-                  },
-                  {
-                    "$ref": "#/definitions/File"
-                  },
-                  {
-                    "$ref": "#/definitions/Capability"
-                  },
-                  {
-                    "$ref": "#/definitions/Entity"
-                  },
-                  {
-                    "$ref": "#/definitions/Event"
-                  },
-                  {
-                    "$ref": "#/definitions/BasicEvent"
-                  },
-                  {
-                    "$ref": "#/definitions/MultiLanguageProperty"
-                  },
-                  {
-                    "$ref": "#/definitions/Operation"
-                  },
-                  {
-                    "$ref": "#/definitions/Property"
-                  },
-                  {
-                    "$ref": "#/definitions/Range"
-                  },
-                  {
-                    "$ref": "#/definitions/ReferenceElement"
-                  },
-                  {
-                    "$ref": "#/definitions/RelationshipElement"
-                  },
-                  {
-                    "$ref": "#/definitions/SubmodelElementCollection"
-                  }
-                ]
-              }
-            },
-            "allowDuplicates": {
-              "type": "boolean"
-            },
-            "ordered": {
-              "type": "boolean"
-            }
-          }
-        }
-      ]
-    },
-    "RelationshipElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "first": {
-              "$ref": "#/definitions/Reference"
-            },
-            "second": {
-              "$ref": "#/definitions/Reference"
-            }
-          },
-          "required": [
-            "first",
-            "second"
-          ]
-        }
-      ]
-    },
-    "AnnotatedRelationshipElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/RelationshipElement"
-        },
-        {
-          "properties": {
-            "annotation": {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/definitions/Blob"
-                  },
-                  {
-                    "$ref": "#/definitions/File"
-                  },
-                  {
-                    "$ref": "#/definitions/MultiLanguageProperty"
-                  },
-                  {
-                    "$ref": "#/definitions/Property"
-                  },
-                  {
-                    "$ref": "#/definitions/Range"
-                  },
-                  {
-                    "$ref": "#/definitions/ReferenceElement"
-                  }
-                ]
-              }
-            }
-          }
-        }
-      ]
-    },
-    "Qualifier": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Constraint"
+          "$ref": "#/definitions/Referable"
         },
         {
           "$ref": "#/definitions/HasSemantics"
         },
         {
-          "$ref": "#/definitions/ValueObject"
+          "$ref": "#/definitions/HasDataSpecification"
         },
         {
           "properties": {
-            "type": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "type"
-          ]
-        }
-      ]
-    },
-    "Formula": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Constraint"
-        },
-        {
-          "properties": {
-            "dependsOn": {
+            "containedElements": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Reference"
@@ -1293,31 +919,253 @@
         }
       ]
     },
-    "Security": {
+    "Reference": {
       "type": "object",
       "properties": {
-        "accessControlPolicyPoints": {
-          "$ref": "#/definitions/AccessControlPolicyPoints"
-        },
-        "certificate": {
+        "keys": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/BlobCertificate"
-              }
-            ]
-          }
-        },
-        "requiredCertificateExtension": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Reference"
+            "$ref": "#/definitions/Key"
           }
         }
       },
       "required": [
-        "accessControlPolicyPoints"
+        "keys"
+      ]
+    },
+    "Key": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/KeyElements"
+        },
+        "value": {
+          "type": "string"
+        },
+        "idType": {
+          "$ref": "#/definitions/KeyType"
+        }
+      },
+      "required": [
+        "type",
+        "value",
+        "idType"
+      ]
+    },
+    "KeyElements": {
+      "type": "string",
+      "enum": [
+        "GlobalReference",
+        "FragmentReference",
+        "AccessPermissionRule",
+        "AnnotatedRelationshipElement",
+        "Asset",
+        "AssetAdministrationShell",
+        "BasicEvent",
+        "Blob",
+        "Capability",
+        "ConceptDescription",
+        "DataElement",
+        "Entity",
+        "Event",
+        "File",
+        "MultiLanguageProperty",
+        "Operation",
+        "Property",
+        "Range",
+        "ReferenceElement",
+        "RelationshipElement",
+        "Submodel",
+        "SubmodelElement",
+        "SubmodelElementCollection",
+        "View"
+      ]
+    },
+    "KeyType": {
+      "type": "string",
+      "enum": [
+        "IdShort",
+        "FragmentId",
+        "IRDI",
+        "IRI",
+        "Custom"
+      ]
+    },
+    "LangString": {
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "language",
+        "text"
+      ]
+    },
+    "DataSpecificationContent": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/DataSpecificationIEC61360Content"
+        },
+        {
+          "$ref": "#/definitions/DataSpecificationPhysicalUnitContent"
+        }
+      ]
+    },
+    "LevelType": {
+      "type": "string",
+      "enum": [
+        "Min",
+        "Max",
+        "Nom",
+        "Typ"
+      ]
+    },
+    "ValueList": {
+      "type": "object",
+      "properties": {
+        "valueReferencePairTypes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ValueReferencePairType"
+          }
+        }
+      },
+      "required": [
+        "valueReferencePairTypes"
+      ]
+    },
+    "DataSpecificationIEC61360Content": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ValueObject"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dataType": {
+              "enum": [
+                "DATE",
+                "STRING",
+                "STRING_TRANSLATABLE",
+                "REAL_MEASURE",
+                "REAL_COUNT",
+                "REAL_CURRENCY",
+                "BOOLEAN",
+                "URL",
+                "RATIONAL",
+                "RATIONAL_MEASURE",
+                "TIME",
+                "TIMESTAMP",
+                "INTEGER_COUNT",
+                "INTEGER_MEASURE",
+                "INTEGER_CURRENCY"
+              ]
+            },
+            "definition": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LangString"
+              }
+            },
+            "preferredName": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LangString"
+              }
+            },
+            "shortName": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LangString"
+              }
+            },
+            "unit": {
+              "type": "string"
+            },
+            "unitId": {
+              "$ref": "#/definitions/Reference"
+            },
+            "sourceOfDefinition": {
+              "type": "string"
+            },
+            "symbol": {
+              "type": "string"
+            },
+            "valueFormat": {
+              "type": "string"
+            },
+            "valueList": {
+              "$ref": "#/definitions/ValueList"
+            },
+            "levelType": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/LevelType"
+              }
+            }
+          },
+          "required": [
+            "preferredName"
+          ]
+        }
+      ]
+    },
+    "DataSpecificationPhysicalUnitContent": {
+      "type": "object",
+      "properties": {
+        "unitName": {
+          "type": "string"
+        },
+        "unitSymbol": {
+          "type": "string"
+        },
+        "definition": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LangString"
+          }
+        },
+        "siNotation": {
+          "type": "string"
+        },
+        "siName": {
+          "type": "string"
+        },
+        "dinNotation": {
+          "type": "string"
+        },
+        "eceName": {
+          "type": "string"
+        },
+        "eceCode": {
+          "type": "string"
+        },
+        "nistName": {
+          "type": "string"
+        },
+        "sourceOfDefinition": {
+          "type": "string"
+        },
+        "conversionFactor": {
+          "type": "string"
+        },
+        "registrationAuthorityId": {
+          "type": "string"
+        },
+        "supplier": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "unitName",
+        "unitSymbol",
+        "definition"
       ]
     },
     "Certificate": {
@@ -1333,119 +1181,77 @@
             "blobCertificate": {
               "$ref": "#/definitions/Blob"
             },
+            "lastCertificate": {
+              "type": "boolean"
+            },
             "containedExtension": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Reference"
               }
-            },
-            "lastCertificate": {
-              "type": "boolean"
             }
           }
         }
       ]
     },
-    "AccessControlPolicyPoints": {
+    "ObjectAttributes": {
       "type": "object",
       "properties": {
-        "policyAdministrationPoint": {
-          "$ref": "#/definitions/PolicyAdministrationPoint"
+        "objectAttribute": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Property"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "Permission": {
+      "type": "object",
+      "properties": {
+        "permission": {
+          "$ref": "#/definitions/Reference"
         },
-        "policyDecisionPoint": {
-          "$ref": "#/definitions/PolicyDecisionPoint"
-        },
-        "policyEnforcementPoint": {
-          "$ref": "#/definitions/PolicyEnforcementPoint"
-        },
-        "policyInformationPoints": {
-          "$ref": "#/definitions/PolicyInformationPoints"
+        "kindOfPermission": {
+          "type": "string",
+          "enum": [
+            "Allow",
+            "Deny",
+            "NotApplicable",
+            "Undefined"
+          ]
         }
       },
       "required": [
-        "policyAdministrationPoint",
-        "policyDecisionPoint",
-        "policyEnforcementPoint"
+        "permission",
+        "kindOfPermission"
       ]
     },
-    "PolicyAdministrationPoint": {
+    "SubjectAttributes": {
       "type": "object",
       "properties": {
-        "localAccessControl": {
-          "$ref": "#/definitions/AccessControl"
-        },
-        "externalAccessControl": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "externalAccessControl"
-      ]
-    },
-    "PolicyInformationPoints": {
-      "type": "object",
-      "properties": {
-        "internalInformationPoint": {
+        "subjectAttributes": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Reference"
-          }
-        },
-        "externalInformationPoint": {
-          "type": "boolean"
+          },
+          "minItems": 1
         }
-      },
-      "required": [
-        "externalInformationPoint"
-      ]
+      }
     },
-    "PolicyEnforcementPoint": {
+    "PermissionsPerObject": {
       "type": "object",
       "properties": {
-        "externalPolicyEnforcementPoint": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "externalPolicyEnforcementPoint"
-      ]
-    },
-    "PolicyDecisionPoint": {
-      "type": "object",
-      "properties": {
-        "externalPolicyDecisionPoints": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "externalPolicyDecisionPoints"
-      ]
-    },
-    "AccessControl": {
-      "type": "object",
-      "properties": {
-        "selectableSubjectAttributes": {
+        "object": {
           "$ref": "#/definitions/Reference"
         },
-        "defaultSubjectAttributes": {
-          "$ref": "#/definitions/Reference"
+        "targetObjectAttributes": {
+          "$ref": "#/definitions/ObjectAttributes"
         },
-        "selectablePermissions": {
-          "$ref": "#/definitions/Reference"
-        },
-        "defaultPermissions": {
-          "$ref": "#/definitions/Reference"
-        },
-        "selectableEnvironmentAttributes": {
-          "$ref": "#/definitions/Reference"
-        },
-        "defaultEnvironmentAttributes": {
-          "$ref": "#/definitions/Reference"
-        },
-        "accessPermissionRule": {
+        "permission": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/AccessPermissionRule"
+            "$ref": "#/definitions/Permission"
           }
         }
       }
@@ -1480,67 +1286,261 @@
         }
       ]
     },
-    "SubjectAttributes": {
+    "AccessControl": {
       "type": "object",
       "properties": {
-        "subjectAttributes": {
+        "accessPermissionRule": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Reference"
-          },
-          "minItems": 1
-        }
-      }
-    },
-    "PermissionsPerObject": {
-      "type": "object",
-      "properties": {
-        "object": {
-          "$ref": "#/definitions/Reference"
-        },
-        "targetObjectAttributes": {
-          "$ref": "#/definitions/ObjectAttributes"
-        },
-        "permission": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Permission"
+            "$ref": "#/definitions/AccessPermissionRule"
           }
-        }
-      }
-    },
-    "ObjectAttributes": {
-      "type": "object",
-      "properties": {
-        "objectAttribute": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Property"
-          },
-          "minItems": 1
-        }
-      }
-    },
-    "Permission": {
-      "type": "object",
-      "properties": {
-        "permission": {
+        },
+        "selectableSubjectAttributes": {
           "$ref": "#/definitions/Reference"
         },
-        "kindOfPermission": {
-          "type": "string",
-          "enum": [
-            "Allow",
-            "Deny",
-            "NotApplicable",
-            "Undefined"
-          ]
+        "defaultSubjectAttributes": {
+          "$ref": "#/definitions/Reference"
+        },
+        "selectablePermissions": {
+          "$ref": "#/definitions/Reference"
+        },
+        "defaultPermissions": {
+          "$ref": "#/definitions/Reference"
+        },
+        "selectableEnvironmentAttributes": {
+          "$ref": "#/definitions/Reference"
+        },
+        "defaultEnvironmentAttributes": {
+          "$ref": "#/definitions/Reference"
+        }
+      }
+    },
+    "PolicyAdministrationPoint": {
+      "type": "object",
+      "properties": {
+        "externalAccessControl": {
+          "type": "boolean"
+        },
+        "localAccessControl": {
+          "$ref": "#/definitions/AccessControl"
         }
       },
       "required": [
-        "permission",
-        "kindOfPermission"
+        "externalAccessControl"
       ]
+    },
+    "PolicyInformationPoints": {
+      "type": "object",
+      "properties": {
+        "externalInformationPoint": {
+          "type": "boolean"
+        },
+        "internalInformationPoint": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          }
+        }
+      },
+      "required": [
+        "externalInformationPoint"
+      ]
+    },
+    "PolicyEnforcementPoint": {
+      "type": "object",
+      "properties": {
+        "externalPolicyEnforcementPoint": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "externalPolicyEnforcementPoint"
+      ]
+    },
+    "PolicyDecisionPoint": {
+      "type": "object",
+      "properties": {
+        "externalPolicyDecisionPoints": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "externalPolicyDecisionPoints"
+      ]
+    },
+    "AccessControlPolicyPoints": {
+      "type": "object",
+      "properties": {
+        "policyAdministrationPoint": {
+          "$ref": "#/definitions/PolicyAdministrationPoint"
+        },
+        "policyDecisionPoint": {
+          "$ref": "#/definitions/PolicyDecisionPoint"
+        },
+        "policyEnforcementPoint": {
+          "$ref": "#/definitions/PolicyEnforcementPoint"
+        },
+        "policyInformationPoints": {
+          "$ref": "#/definitions/PolicyInformationPoints"
+        }
+      },
+      "required": [
+        "policyAdministrationPoint",
+        "policyDecisionPoint",
+        "policyEnforcementPoint"
+      ]
+    },
+    "Security": {
+      "type": "object",
+      "properties": {
+        "accessControlPolicyPoints": {
+          "$ref": "#/definitions/AccessControlPolicyPoints"
+        },
+        "certificate": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/BlobCertificate"
+              }
+            ]
+          }
+        },
+        "requiredCertificateExtension": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          }
+        }
+      },
+      "required": [
+        "accessControlPolicyPoints"
+      ]
+    },
+    "ModelTypes": {
+      "type": "string",
+      "enum": [
+        "Qualifier",
+        "Formula",
+        "AssetAdministrationShell",
+        "Asset",
+        "Submodel",
+        "RelationshipElement",
+        "SubmodelElementCollection",
+        "Property",
+        "MultiLanguageProperty",
+        "Range",
+        "ReferenceElement",
+        "Blob",
+        "File",
+        "AnnotatedRelationshipElement",
+        "Entity",
+        "Event",
+        "BasicEvent",
+        "Operation",
+        "ConceptDescription",
+        "View",
+        "Capability",
+        "DataElement",
+        "SubmodelElement",
+        "GlobalReference",
+        "FragmentReference",
+        "Constraint",
+        "AccessPermissionRule"
+      ]
+    },
+    "ModelType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/ModelTypes"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "EmbeddedDataSpecification": {
+      "type": "object",
+      "properties": {
+        "dataSpecification": {
+          "$ref": "#/definitions/Reference"
+        },
+        "dataSpecificationContent": {
+          "$ref": "#/definitions/DataSpecificationContent"
+        }
+      },
+      "required": [
+        "dataSpecification",
+        "dataSpecificationContent"
+      ]
+    },
+    "ValueReferencePairType": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ValueObject"
+        }
+      ]
+    },
+    "ValueObject": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "valueId": {
+          "$ref": "#/definitions/Reference"
+        },
+        "valueType": {
+          "type": "string",
+          "enum": [
+            "anyUri",
+            "base64Binary",
+            "boolean",
+            "date",
+            "dateTime",
+            "dateTimeStamp",
+            "decimal",
+            "integer",
+            "long",
+            "int",
+            "short",
+            "byte",
+            "nonNegativeInteger",
+            "positiveInteger",
+            "unsignedLong",
+            "unsignedInt",
+            "unsignedShort",
+            "unsignedByte",
+            "nonPositiveInteger",
+            "negativeInteger",
+            "double",
+            "duration",
+            "dayTimeDuration",
+            "yearMonthDuration",
+            "float",
+            "gDay",
+            "gMonth",
+            "gMonthDay",
+            "gYear",
+            "gYearMonth",
+            "hexBinary",
+            "NOTATION",
+            "QName",
+            "string",
+            "normalizedString",
+            "token",
+            "language",
+            "Name",
+            "NCName",
+            "ENTITY",
+            "ID",
+            "IDREF",
+            "NMTOKEN",
+            "time"
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This patch re-orders the definitions in the JSON schema to make it
easier to compare against a generated JSON schema.

The diff to master has been checked with http://http://www.jsondiff.com
and:

```
cat aas.json|sort > /tmp/a
git show master:./aas.json|sort > /tmp/b
diff /tmp/a /tmp/b
```