### PR TITLE
Refactor `LangStringSet` to a JSON definition

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -144,10 +144,7 @@
               "type": "string"
             },
             "description": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
+              "$ref": "#/definitions/LangStringSet"
             },
             "modelType": {
               "$ref": "#/definitions/ModelType"
@@ -558,10 +555,7 @@
         {
           "properties": {
             "value": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
+              "$ref": "#/definitions/LangStringSet"
             },
             "valueId": {
               "$ref": "#/definitions/Reference"
@@ -1006,6 +1000,12 @@
         "text"
       ]
     },
+    "LangStringSet": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LangString"
+      }
+    },
     "DataSpecificationContent": {
       "oneOf": [
         {
@@ -1068,22 +1068,13 @@
               ]
             },
             "definition": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
+              "$ref": "#/definitions/LangStringSet"
             },
             "preferredName": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
+              "$ref": "#/definitions/LangStringSet"
             },
             "shortName": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/LangString"
-              }
+              "$ref": "#/definitions/LangStringSet"
             },
             "unit": {
               "type": "string"
@@ -1126,10 +1117,7 @@
           "type": "string"
         },
         "definition": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/LangString"
-          }
+          "$ref": "#/definitions/LangStringSet"
         },
         "siNotation": {
           "type": "string"


### PR DESCRIPTION
We repeatedly defined `LangStringSet`'s in an in-line fashion. With this
patch, we refactor it to a proper JSON definition and reference it where
necessary.