### PR TITLE
Fix plurals in JSON Schema

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -484,7 +484,7 @@
         },
         {
           "properties": {
-            "values": {
+            "value": {
               "type": "array",
               "items": {
                 "oneOf": [

--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -484,7 +484,7 @@
         },
         {
           "properties": {
-            "value": {
+            "values": {
               "type": "array",
               "items": {
                 "oneOf": [
@@ -700,7 +700,7 @@
         },
         {
           "properties": {
-            "annotation": {
+            "annotations": {
               "type": "array",
               "items": {
                 "oneOf": [
@@ -796,19 +796,19 @@
         },
         {
           "properties": {
-            "inputVariable": {
+            "inputVariables": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/OperationVariable"
               }
             },
-            "outputVariable": {
+            "outputVariables": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/OperationVariable"
               }
             },
-            "inoutputVariable": {
+            "inoutputVariables": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/OperationVariable"
@@ -1184,7 +1184,7 @@
             "lastCertificate": {
               "type": "boolean"
             },
-            "containedExtension": {
+            "containedExtensions": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Reference"
@@ -1197,7 +1197,7 @@
     "ObjectAttributes": {
       "type": "object",
       "properties": {
-        "objectAttribute": {
+        "objectAttributes": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Property"
@@ -1248,7 +1248,7 @@
         "targetObjectAttributes": {
           "$ref": "#/definitions/ObjectAttributes"
         },
-        "permission": {
+        "permissions": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Permission"
@@ -1273,7 +1273,7 @@
               },
               "minItems": 1
             },
-            "permissionsPerObject": {
+            "permissionsPerObjects": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/PermissionsPerObject"
@@ -1289,7 +1289,7 @@
     "AccessControl": {
       "type": "object",
       "properties": {
-        "accessPermissionRule": {
+        "accessPermissionRules": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/AccessPermissionRule"
@@ -1335,7 +1335,7 @@
         "externalInformationPoint": {
           "type": "boolean"
         },
-        "internalInformationPoint": {
+        "internalInformationPoints": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Reference"
@@ -1396,7 +1396,7 @@
         "accessControlPolicyPoints": {
           "$ref": "#/definitions/AccessControlPolicyPoints"
         },
-        "certificate": {
+        "certificates": {
           "type": "array",
           "items": {
             "oneOf": [
@@ -1406,7 +1406,7 @@
             ]
           }
         },
-        "requiredCertificateExtension": {
+        "requiredCertificateExtensions": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Reference"


### PR DESCRIPTION
Some of the plurals in the property names were omitted by mistake. This
patch fixes the omissions.