### PR TITLE
Remove non-critical annotations in RDF

### DIFF
--- a/schemas/rdf/rdf-ontology.ttl
+++ b/schemas/rdf/rdf-ontology.ttl
@@ -365,7 +365,6 @@ aas:Blob rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC01/Blob/mimeType
 <https://admin-shell.io/aas/3/0/RC01/Blob/mimeType> rdf:type owl:DatatypeProperty ;
-    rdfs:seeAlso "http://uri4uri.net/vocab.html/#MimetypeDatatype"^^xsd:string ;
     rdfs:label "has mime type"^^xsd:string ;
     rdfs:domain aas:Blob ;
     rdfs:range xsd:string ;


### PR DESCRIPTION
We missed to remove an annotation in the previous commit, so we do it in
this one.