### PR TITLE
Make `blobCertificate` use blob in RDF

### DIFF
--- a/schemas/rdf/rdf-ontology.ttl
+++ b/schemas/rdf/rdf-ontology.ttl
@@ -386,10 +386,10 @@ aas:BlobCertificate rdf:type owl:Class ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/BlobCertificate/blobCertificate
-<https://admin-shell.io/aas/3/0/RC01/BlobCertificate/blobCertificate> rdf:type owl:DatatypeProperty ;
+<https://admin-shell.io/aas/3/0/RC01/BlobCertificate/blobCertificate> rdf:type owl:ObjectProperty ;
     rdfs:label "has blob certificate"^^xsd:string ;
     rdfs:domain aas:BlobCertificate ;
-    rdfs:range xsd:byte ;
+    rdfs:range aas:Blob ;
     rdfs:comment "Certificate as BLOB."@en ;
 .
 


### PR DESCRIPTION
We erroneously wrote `xsd:byte` instead of `Blob`.