### PR TITLE
Ignore temporal BASH scripts in RDF

### DIFF
--- a/schemas/rdf/.gitignore
+++ b/schemas/rdf/.gitignore
@@ -1,1 +1,2 @@
 deleteme.py
+deleteme.sh


### PR DESCRIPTION
We use temporal scripts to re-format and re-order the SHACL and RDF
schemas whose quality is too low so they should not be checked in and
re-used.