### PR TITLE
Remove shapes from SHACL which are not in book

### DIFF
--- a/schemas/rdf/shacl-schema.ttl
+++ b/schemas/rdf/shacl-schema.ttl
@@ -769,18 +769,6 @@ aas:EventShape a sh:NodeShape ;
     ] ;
 .
 
-aas:EventElementShape a sh:NodeShape ;
-  rdfs:subClassOf aas:SubmodelElementShape ;
-  sh:targetClass aas:EventElement ;
-  skos:note "As of November 2019, EventElement is not mandatory. This shape serves as a stump for further definitions."@en ;
-.
-
-aas:EventMessageShape a sh:NodeShape ;
-  rdfs:subClassOf aas:SubmodelElementShape ;
-  sh:targetClass aas:EventMessage ;
-  skos:note "As of November 2019, EventMessage is not mandatory. This shape serves as a stump for further definitions."@en ;
-.
-
 aas:ExtensionShape a sh:NodeShape ;
   sh:targetClass aas:Extension ;
   rdfs:subClassOf aas:HasSemanticsShape ;


### PR DESCRIPTION
A couple of shapes were defined for classes eventually removed from the
V3RC01.