### PR TITLE
Revert `ID` to `Id` in SHACL

### DIFF
--- a/schemas/rdf/shacl-schema.ttl
+++ b/schemas/rdf/shacl-schema.ttl
@@ -535,9 +535,9 @@ iec61360:DataSpecificationIEC61360Shape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0/RC01/DataSpecificationIEC61360/valueID> ;
+        sh:path <https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0/RC01/DataSpecificationIEC61360/valueId> ;
         sh:maxCount 1 ;
-        sh:message "(DataSpecificationIEC61360.valueID):A <i>valueID</i> must have a Reference"^^xsd:string ;
+        sh:message "(DataSpecificationIEC61360.valueId):A <i>valueId</i> must have a Reference"^^xsd:string ;
         sh:minCount 0 ;
         sh:class aas:Reference ;
     ] ;
@@ -915,11 +915,11 @@ aas:HasSemanticsShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC01/HasSemantics/semanticID> ;
+        sh:path <https://admin-shell.io/aas/3/0/RC01/HasSemantics/semanticId> ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:class aas:Reference ;
-        sh:message "(HasSemantics.semanticID):Only one value for <i>semanticID</i> is allowed."^^xsd:string ;
+        sh:message "(HasSemantics.semanticId):Only one value for <i>semanticId</i> is allowed."^^xsd:string ;
     ] ;
 .
 
@@ -1051,11 +1051,11 @@ aas:MultiLanguagePropertyShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC01/MultiLanguageProperty/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/RC01/MultiLanguageProperty/valueId> ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:class aas:Reference ;
-        sh:message "(MultiLanguageProperty.valueID):Only one <i>valueID</i> attribute having a <i>Reference</i> is allowed"^^xsd:string ;
+        sh:message "(MultiLanguageProperty.valueId):Only one <i>valueId</i> attribute having a <i>Reference</i> is allowed"^^xsd:string ;
     ] ;
 .
 
@@ -1239,11 +1239,11 @@ aas:PropertyShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC01/Property/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/RC01/Property/valueId> ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:class aas:Reference ;
-        sh:message "(Property.valueID):Only one <i>valueID</i> is allowed"^^xsd:string ;
+        sh:message "(Property.valueId):Only one <i>valueId</i> is allowed"^^xsd:string ;
     ] ;
 .
 
@@ -1300,11 +1300,11 @@ aas:QualifierShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC01/Qualifier/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/RC01/Qualifier/valueId> ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:class aas:Reference ;
-        sh:message "(Qualifier.valueID):Only one <i>valueID</i> having a <i>Reference</i> entity is allowed."^^xsd:string ;
+        sh:message "(Qualifier.valueId):Only one <i>valueId</i> having a <i>Reference</i> entity is allowed."^^xsd:string ;
     ] ;
 .
 
@@ -1560,11 +1560,11 @@ aas:ValueReferencePairShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC01/ValueReferencePair/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/RC01/ValueReferencePair/valueId> ;
         sh:datatype aas:Reference ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:message "(ValueReferencePair.valueID):Only one <i>Reference</i> is allowed for <i>valueID</i>."^^xsd:string ;
+        sh:message "(ValueReferencePair.valueId):Only one <i>Reference</i> is allowed for <i>valueId</i>."^^xsd:string ;
     ] ;
 .
 


### PR DESCRIPTION
We revert `ID` to `Id` since the initialism "ID" is considered an
exception in the book.