### PR TITLE
Define `DataElement` in JSON

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -454,10 +454,13 @@
         }
       ]
     },
+    "DataElement": {
+      "$ref": "#/definitions/SubmodelElement"
+    },
     "Property": {
       "allOf": [
         {
-          "$ref": "#/definitions/SubmodelElement"
+          "$ref": "#/definitions/DataElement"
         },
         {
           "properties": {
@@ -480,7 +483,7 @@
     "MultiLanguageProperty": {
       "allOf": [
         {
-          "$ref": "#/definitions/SubmodelElement"
+          "$ref": "#/definitions/DataElement"
         },
         {
           "properties": {
@@ -497,7 +500,7 @@
     "Range": {
       "allOf": [
         {
-          "$ref": "#/definitions/SubmodelElement"
+          "$ref": "#/definitions/DataElement"
         },
         {
           "properties": {
@@ -520,7 +523,7 @@
     "ReferenceElement": {
       "allOf": [
         {
-          "$ref": "#/definitions/SubmodelElement"
+          "$ref": "#/definitions/DataElement"
         },
         {
           "properties": {
@@ -534,7 +537,7 @@
     "Blob": {
       "allOf": [
         {
-          "$ref": "#/definitions/SubmodelElement"
+          "$ref": "#/definitions/DataElement"
         },
         {
           "properties": {
@@ -554,7 +557,7 @@
     "File": {
       "allOf": [
         {
-          "$ref": "#/definitions/SubmodelElement"
+          "$ref": "#/definitions/DataElement"
         },
         {
           "properties": {


### PR DESCRIPTION
This makes the schema easier to trace from the book even though the
definition for `DataElement` just points to `SubmodelElement`.