### PR TITLE
Fix inheritances in JSON

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -153,6 +153,14 @@
         "Instance"
       ]
     },
+    "HasKind": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ModelingKind"
+        }
+      }
+    },
     "HasDataSpecification": {
       "type": "object",
       "properties": {
@@ -165,15 +173,21 @@
       }
     },
     "AdministrativeInformation": {
-      "type": "object",
-      "properties": {
-        "version": {
-          "type": "string"
+      "allOf": [
+        {
+          "$ref": "#/definitions/HasDataSpecification"
         },
-        "revision": {
-          "type": "string"
+        {
+          "properties": {
+            "version": {
+              "type": "string"
+            },
+            "revision": {
+              "type": "string"
+            }
+          }
         }
-      }
+      ]
     },
     "Qualifiable": {
       "type": "object",
@@ -358,19 +372,19 @@
           "$ref": "#/definitions/Identifiable"
         },
         {
-          "$ref": "#/definitions/HasDataSpecification"
-        },
-        {
-          "$ref": "#/definitions/Qualifiable"
+          "$ref": "#/definitions/HasKind"
         },
         {
           "$ref": "#/definitions/HasSemantics"
         },
         {
+          "$ref": "#/definitions/Qualifiable"
+        },
+        {
+          "$ref": "#/definitions/HasDataSpecification"
+        },
+        {
           "properties": {
-            "kind": {
-              "$ref": "#/definitions/ModelingKind"
-            },
             "submodelElements": {
               "type": "array",
               "items": {
@@ -387,7 +401,7 @@
           "$ref": "#/definitions/Referable"
         },
         {
-          "$ref": "#/definitions/HasDataSpecification"
+          "$ref": "#/definitions/HasKind"
         },
         {
           "$ref": "#/definitions/HasSemantics"
@@ -396,17 +410,7 @@
           "$ref": "#/definitions/Qualifiable"
         },
         {
-          "properties": {
-            "kind": {
-              "$ref": "#/definitions/ModelingKind"
-            },
-            "idShort": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "idShort"
-          ]
+          "$ref": "#/definitions/HasDataSpecification"
         }
       ]
     },


### PR DESCRIPTION
Some of the definitions lacked the inheritances from `HasKind` and
`HasDataSpecification`. We fixed that so that the schema follows the
book.