### PR TITLE
Fix `ModelTypes` enumeration in JSON

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -1391,17 +1391,17 @@
         "File",
         "AnnotatedRelationshipElement",
         "Entity",
-        "Event",
+
         "BasicEvent",
         "Operation",
+        "Capability",
         "ConceptDescription",
         "View",
-        "Capability",
-        "DataElement",
-        "SubmodelElement",
-        "GlobalReference",
-        "FragmentReference",
-        "Constraint",
+
+
+
+
+
         "AccessPermissionRule"
       ]
     },


### PR DESCRIPTION
We remove the abstract classes from `ModelTypes` enumeration and
re-order the literals to match the order of the automatically generated
JSON schema.