### PR TITLE
Add `BlobCertificate` to `ModelTypes` in JSON

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -1391,17 +1391,12 @@
         "File",
         "AnnotatedRelationshipElement",
         "Entity",
-
         "BasicEvent",
         "Operation",
         "Capability",
         "ConceptDescription",
         "View",
-
-
-
-
-
+        "BlobCertificate",
         "AccessPermissionRule"
       ]
     },


### PR DESCRIPTION
We list `BlobCertificate` in the enumeration `ModelTypes` since it is a
referable and was unintentionally omitted previously.