### PR TITLE
Make properties of environment optional in JSON

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -1365,13 +1365,7 @@
             "$ref": "#/definitions/ConceptDescription"
           }
         }
-      },
-      "required": [
-        "assetAdministrationShells",
-        "assets",
-        "submodels",
-        "conceptDescriptions"
-      ]
+      }
     },
     "ModelTypes": {
       "type": "string",


### PR DESCRIPTION
We make all the properties of `AssetAdministrationShellEnvironment`
optional in JSON to be consistent with other properties given as arrays.
This change also makes the JSON schema more consistent with the SHACL
schema and thus easier to follow and compare.