### PR TITLE
Sort children of `<schema>` in XSD

### DIFF
--- a/schemas/xml/AAS.xsd
+++ b/schemas/xml/AAS.xsd
@@ -1,273 +1,5 @@
 <?xml version="1.0" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.admin-shell.io/aas/3/0/RC02" elementFormDefault="qualified" targetNamespace="http://www.admin-shell.io/aas/3/0/RC02">
-  
-    
-  <xs:element name="environment" type="environment_t"/>
-  
-
-  <xs:group name="resource">
-    <xs:sequence>
-      <xs:element name="path" type="assetKind_t"/>
-      <xs:element name="contentType" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:pattern value="^([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*$"/>
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="resource_t">
-    <xs:sequence>
-      <xs:group ref="resource"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="hasSemantics">
-    <xs:sequence>
-      <xs:element name="semanticId" type="globalReference_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="hasSemantics_t">
-    <xs:sequence>
-      <xs:group ref="hasSemantics"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="hasSemantics_choice">
-    <xs:choice>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="extension" type="extension_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="identifierKeyValuePair" type="identifierKeyValuePair_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="qualifier" type="qualifier_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-      <xs:element name="submodel" type="submodel_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
-      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
-      <xs:element name="view" type="view_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="extension">
-    <xs:sequence>
-      <xs:group ref="hasSemantics"/>
-      <xs:element name="name">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="refersTo" type="modelReference_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="extension_t">
-    <xs:sequence>
-      <xs:group ref="extension"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="hasExtensions">
-    <xs:sequence>
-      <xs:element name="extensions" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="extension" type="extension_t" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="hasExtensions_t">
-    <xs:sequence>
-      <xs:group ref="hasExtensions"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="hasExtensions_choice">
-    <xs:choice>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="conceptDescription" type="conceptDescription_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-      <xs:element name="submodel" type="submodel_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
-      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
-      <xs:element name="view" type="view_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="referable">
-    <xs:sequence>
-      <xs:group ref="hasExtensions"/>
-      <xs:element name="idShort" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-            <xs:maxLength value="128"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="displayName" type="langStringSet_t" minOccurs="0"/>
-      <xs:element name="category" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="description" type="langStringSet_t" minOccurs="0"/>
-      <xs:element name="checksum" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="referable_t">
-    <xs:sequence>
-      <xs:group ref="referable"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="referable_choice">
-    <xs:choice>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="conceptDescription" type="conceptDescription_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-      <xs:element name="submodel" type="submodel_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
-      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
-      <xs:element name="view" type="view_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="identifiable">
-    <xs:sequence>
-      <xs:group ref="referable"/>
-      <xs:element name="id">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="administration" type="administrativeInformation_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="identifiable_t">
-    <xs:sequence>
-      <xs:group ref="identifiable"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="identifiable_choice">
-    <xs:choice>
-      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
-      <xs:element name="conceptDescription" type="conceptDescription_t"/>
-      <xs:element name="submodel" type="submodel_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:simpleType name="modelingKind_t">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="TEMPLATE"/>
-      <xs:enumeration value="INSTANCE"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:group name="hasKind">
-    <xs:sequence>
-      <xs:element name="kind" type="modelingKind_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="hasKind_t">
-    <xs:sequence>
-      <xs:group ref="hasKind"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="hasKind_choice">
-    <xs:choice>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-      <xs:element name="submodel" type="submodel_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
-      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="hasDataSpecification">
-    <xs:sequence>
-      <xs:element name="dataSpecifications" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="globalReference" type="globalReference_t" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="hasDataSpecification_t">
-    <xs:sequence>
-      <xs:group ref="hasDataSpecification"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="hasDataSpecification_choice">
-    <xs:choice>
-      <xs:element name="administrativeInformation" type="administrativeInformation_t"/>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="conceptDescription" type="conceptDescription_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-      <xs:element name="submodel" type="submodel_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
-      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
-      <xs:element name="view" type="view_t"/>
-    </xs:choice>
-  </xs:group>
   <xs:group name="administrativeInformation">
     <xs:sequence>
       <xs:group ref="hasDataSpecification"/>
@@ -287,69 +19,18 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="administrativeInformation_t">
+  <xs:group name="annotatedRelationshipElement">
     <xs:sequence>
-      <xs:group ref="administrativeInformation"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="qualifiable">
-    <xs:sequence>
-      <xs:element name="qualifiers" minOccurs="0">
+      <xs:group ref="relationshipElement"/>
+      <xs:element name="annotation" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="qualifier" type="qualifier_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="dataElement_choice" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="qualifiable_t">
-    <xs:sequence>
-      <xs:group ref="qualifiable"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="qualifiable_choice">
-    <xs:choice>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-      <xs:element name="submodel" type="submodel_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
-      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="qualifier">
-    <xs:sequence>
-      <xs:group ref="hasSemantics"/>
-      <xs:element name="type">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="qualifier_t">
-    <xs:sequence>
-      <xs:group ref="qualifier"/>
-    </xs:sequence>
-  </xs:complexType>
   <xs:group name="assetAdministrationShell">
     <xs:sequence>
       <xs:group ref="identifiable"/>
@@ -365,11 +46,6 @@
       <xs:element name="derivedFrom" type="modelReference_t" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="assetAdministrationShell_t">
-    <xs:sequence>
-      <xs:group ref="assetAdministrationShell"/>
-    </xs:sequence>
-  </xs:complexType>
   <xs:group name="assetInformation">
     <xs:sequence>
       <xs:element name="assetKind" type="assetKind_t"/>
@@ -377,408 +53,6 @@
       <xs:element name="specificAssetId" type="identifierKeyValuePair_t" minOccurs="0"/>
       <xs:element name="defaultThumbnail" type="resource_t" minOccurs="0"/>
     </xs:sequence>
-  </xs:group>
-  <xs:complexType name="assetInformation_t">
-    <xs:sequence>
-      <xs:group ref="assetInformation"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:simpleType name="assetKind_t">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="Type"/>
-      <xs:enumeration value="Instance"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:group name="identifierKeyValuePair">
-    <xs:sequence>
-      <xs:group ref="hasSemantics"/>
-      <xs:element name="key">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="value">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="externalSubjectId" type="globalReference_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="identifierKeyValuePair_t">
-    <xs:sequence>
-      <xs:group ref="identifierKeyValuePair"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="submodel">
-    <xs:sequence>
-      <xs:group ref="identifiable"/>
-      <xs:group ref="hasKind"/>
-      <xs:group ref="hasSemantics"/>
-      <xs:group ref="qualifiable"/>
-      <xs:group ref="hasDataSpecification"/>
-      <xs:element name="submodelElements" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="submodel_t">
-    <xs:sequence>
-      <xs:group ref="submodel"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="submodelElement">
-    <xs:sequence>
-      <xs:group ref="referable"/>
-      <xs:group ref="hasKind"/>
-      <xs:group ref="hasSemantics"/>
-      <xs:group ref="qualifiable"/>
-      <xs:group ref="hasDataSpecification"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="submodelElement_t">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="submodelElement_choice">
-    <xs:choice>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="capability" type="capability_t"/>
-      <xs:element name="entity" type="entity_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="operation" type="operation_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-      <xs:element name="submodelElementList" type="submodelElementList_t"/>
-      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="relationshipElement">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
-      <xs:element name="first">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="reference_choice"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="second">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="reference_choice"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="relationshipElement_t">
-    <xs:sequence>
-      <xs:group ref="relationshipElement"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="relationshipElement_choice">
-    <xs:choice>
-      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="submodelElementList">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
-      <xs:element name="typeValueListElement" type="submodelElementElements_t"/>
-      <xs:element name="orderRelevant" type="xs:boolean" minOccurs="0"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="semanticIdListElement" type="globalReference_t" minOccurs="0"/>
-      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="submodelElementList_t">
-    <xs:sequence>
-      <xs:group ref="submodelElementList"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="submodelElementStruct">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="submodelElementStruct_t">
-    <xs:sequence>
-      <xs:group ref="submodelElementStruct"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="dataElement">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="dataElement_t">
-    <xs:sequence>
-      <xs:group ref="dataElement"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="dataElement_choice">
-    <xs:choice>
-      <xs:element name="blob" type="blob_t"/>
-      <xs:element name="file" type="file_t"/>
-      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
-      <xs:element name="property" type="property_t"/>
-      <xs:element name="range" type="range_t"/>
-      <xs:element name="referenceElement" type="referenceElement_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="property">
-    <xs:sequence>
-      <xs:group ref="dataElement"/>
-      <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="property_t">
-    <xs:sequence>
-      <xs:group ref="property"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="multiLanguageProperty">
-    <xs:sequence>
-      <xs:group ref="dataElement"/>
-      <xs:element name="value" type="langStringSet_t" minOccurs="0"/>
-      <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="multiLanguageProperty_t">
-    <xs:sequence>
-      <xs:group ref="multiLanguageProperty"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="range">
-    <xs:sequence>
-      <xs:group ref="dataElement"/>
-      <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="min" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="max" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="range_t">
-    <xs:sequence>
-      <xs:group ref="range"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="referenceElement">
-    <xs:sequence>
-      <xs:group ref="dataElement"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="reference_choice"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="referenceElement_t">
-    <xs:sequence>
-      <xs:group ref="referenceElement"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="blob">
-    <xs:sequence>
-      <xs:group ref="dataElement"/>
-      <xs:element name="mimeType">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:pattern value="^([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*$"/>
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:base64Binary"/>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="blob_t">
-    <xs:sequence>
-      <xs:group ref="blob"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="file">
-    <xs:sequence>
-      <xs:group ref="dataElement"/>
-      <xs:element name="contentType">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:pattern value="^([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*$"/>
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:pattern value="^file:(//((localhost|(\[((([0-9A-Fa-f]{1,4}:){6}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|::([0-9A-Fa-f]{1,4}:){5}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){4}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){3}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){2}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){2}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){4}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}:){6}[0-9A-Fa-f]{1,4})?::)|[vV][0-9A-Fa-f]+\.([a-zA-Z0-9\-._~]|[!$&amp;'()*+,;=]|:)+)\]|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=])*)))?/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?|/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?)$"/>
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="file_t">
-    <xs:sequence>
-      <xs:group ref="file"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="annotatedRelationshipElement">
-    <xs:sequence>
-      <xs:group ref="relationshipElement"/>
-      <xs:element name="annotation" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="dataElement_choice" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="annotatedRelationshipElement_t">
-    <xs:sequence>
-      <xs:group ref="annotatedRelationshipElement"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:simpleType name="entityType_t">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="COMANAGEDENTITY"/>
-      <xs:enumeration value="SELFMANAGEDENTITY"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:group name="entity">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
-      <xs:element name="entityType" type="entityType_t"/>
-      <xs:element name="statements" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="globalAssetId" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:group ref="reference_choice"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="specificAssetId" type="identifierKeyValuePair_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="entity_t">
-    <xs:sequence>
-      <xs:group ref="entity"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:simpleType name="direction_t">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="INPUT"/>
-      <xs:enumeration value="OUTPUT"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="stateOfEvent_t">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="ON"/>
-      <xs:enumeration value="OFF"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:group name="eventPayload">
-    <xs:sequence>
-      <xs:element name="source" type="modelReference_t"/>
-      <xs:element name="sourceSemanticId" type="globalReference_t" minOccurs="0"/>
-      <xs:element name="observableReference" type="modelReference_t"/>
-      <xs:element name="observableSemanticId" type="globalReference_t" minOccurs="0"/>
-      <xs:element name="topic" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="subjectId" type="globalReference_t" minOccurs="0"/>
-      <xs:element name="timeStamp">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:pattern value="^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)Z$"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="payload" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="eventPayload_t">
-    <xs:sequence>
-      <xs:group ref="eventPayload"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="eventElement">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="eventElement_t">
-    <xs:sequence>
-      <xs:group ref="eventElement"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="eventElement_choice">
-    <xs:choice>
-      <xs:element name="basicEventElement" type="basicEventElement_t"/>
-    </xs:choice>
   </xs:group>
   <xs:group name="basicEventElement">
     <xs:sequence>
@@ -817,11 +91,405 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="basicEventElement_t">
+  <xs:group name="blob">
     <xs:sequence>
-      <xs:group ref="basicEventElement"/>
+      <xs:group ref="dataElement"/>
+      <xs:element name="mimeType">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="^([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*$"/>
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="value" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:base64Binary"/>
+        </xs:simpleType>
+      </xs:element>
     </xs:sequence>
-  </xs:complexType>
+  </xs:group>
+  <xs:group name="capability">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="conceptDescription">
+    <xs:sequence>
+      <xs:group ref="identifiable"/>
+      <xs:group ref="hasDataSpecification"/>
+      <xs:element name="isCaseOf" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="globalReference" type="globalReference_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="dataElement">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="dataElement_choice">
+    <xs:choice>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="entity">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+      <xs:element name="entityType" type="entityType_t"/>
+      <xs:element name="statements" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="globalAssetId" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="reference_choice"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="specificAssetId" type="identifierKeyValuePair_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="environment">
+    <xs:sequence>
+      <xs:element name="assetAdministrationShells" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="submodels" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="submodel" type="submodel_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="conceptDescriptions" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="conceptDescription" type="conceptDescription_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="eventElement">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="eventElement_choice">
+    <xs:choice>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="eventPayload">
+    <xs:sequence>
+      <xs:element name="source" type="modelReference_t"/>
+      <xs:element name="sourceSemanticId" type="globalReference_t" minOccurs="0"/>
+      <xs:element name="observableReference" type="modelReference_t"/>
+      <xs:element name="observableSemanticId" type="globalReference_t" minOccurs="0"/>
+      <xs:element name="topic" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="subjectId" type="globalReference_t" minOccurs="0"/>
+      <xs:element name="timeStamp">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\.[0-9]+)?)|24:00:00(\.0+)?)Z$"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="payload" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="extension">
+    <xs:sequence>
+      <xs:group ref="hasSemantics"/>
+      <xs:element name="name">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0"/>
+      <xs:element name="value" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="refersTo" type="modelReference_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="file">
+    <xs:sequence>
+      <xs:group ref="dataElement"/>
+      <xs:element name="contentType">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="^([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*$"/>
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="value" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="^file:(//((localhost|(\[((([0-9A-Fa-f]{1,4}:){6}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|::([0-9A-Fa-f]{1,4}:){5}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){4}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){3}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){2}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){2}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){4}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}:){6}[0-9A-Fa-f]{1,4})?::)|[vV][0-9A-Fa-f]+\.([a-zA-Z0-9\-._~]|[!$&amp;'()*+,;=]|:)+)\]|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=])*)))?/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?|/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?)$"/>
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="globalReference">
+    <xs:sequence>
+      <xs:group ref="reference"/>
+      <xs:element name="value">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="hasDataSpecification">
+    <xs:sequence>
+      <xs:element name="dataSpecifications" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="globalReference" type="globalReference_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="hasDataSpecification_choice">
+    <xs:choice>
+      <xs:element name="administrativeInformation" type="administrativeInformation_t"/>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="capability" type="capability_t"/>
+      <xs:element name="conceptDescription" type="conceptDescription_t"/>
+      <xs:element name="entity" type="entity_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="operation" type="operation_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+      <xs:element name="submodel" type="submodel_t"/>
+      <xs:element name="submodelElementList" type="submodelElementList_t"/>
+      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
+      <xs:element name="view" type="view_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="hasExtensions">
+    <xs:sequence>
+      <xs:element name="extensions" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="extension" type="extension_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="hasExtensions_choice">
+    <xs:choice>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="capability" type="capability_t"/>
+      <xs:element name="conceptDescription" type="conceptDescription_t"/>
+      <xs:element name="entity" type="entity_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="operation" type="operation_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+      <xs:element name="submodel" type="submodel_t"/>
+      <xs:element name="submodelElementList" type="submodelElementList_t"/>
+      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
+      <xs:element name="view" type="view_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="hasKind">
+    <xs:sequence>
+      <xs:element name="kind" type="modelingKind_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="hasKind_choice">
+    <xs:choice>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="capability" type="capability_t"/>
+      <xs:element name="entity" type="entity_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="operation" type="operation_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+      <xs:element name="submodel" type="submodel_t"/>
+      <xs:element name="submodelElementList" type="submodelElementList_t"/>
+      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="hasSemantics">
+    <xs:sequence>
+      <xs:element name="semanticId" type="globalReference_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="hasSemantics_choice">
+    <xs:choice>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="capability" type="capability_t"/>
+      <xs:element name="entity" type="entity_t"/>
+      <xs:element name="extension" type="extension_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="identifierKeyValuePair" type="identifierKeyValuePair_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="operation" type="operation_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="qualifier" type="qualifier_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+      <xs:element name="submodel" type="submodel_t"/>
+      <xs:element name="submodelElementList" type="submodelElementList_t"/>
+      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
+      <xs:element name="view" type="view_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="identifiable">
+    <xs:sequence>
+      <xs:group ref="referable"/>
+      <xs:element name="id">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="administration" type="administrativeInformation_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="identifiable_choice">
+    <xs:choice>
+      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
+      <xs:element name="conceptDescription" type="conceptDescription_t"/>
+      <xs:element name="submodel" type="submodel_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="identifierKeyValuePair">
+    <xs:sequence>
+      <xs:group ref="hasSemantics"/>
+      <xs:element name="key">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="value">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="externalSubjectId" type="globalReference_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="key">
+    <xs:sequence>
+      <xs:element name="type" type="keyElements_t"/>
+      <xs:element name="value">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="langString">
+    <xs:sequence>
+      <xs:element name="language">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="^(([a-zA-Z]{2,3}(-[a-zA-Z]{3}(-[a-zA-Z]{3}){2})?|[a-zA-Z]{4}|[a-zA-Z]{5,8})(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-(([a-zA-Z0-9]){5,8}|[0-9]([a-zA-Z0-9]){3}))*(-[0-9A-WY-Za-wy-z](-([a-zA-Z0-9]){2,8})+)*(-[xX](-([a-zA-Z0-9]){1,8})+)?|[xX](-([a-zA-Z0-9]){1,8})+|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="text" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="langStringSet">
+    <xs:sequence>
+      <xs:element name="langStrings">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="modelReference">
+    <xs:sequence>
+      <xs:group ref="reference"/>
+      <xs:element name="keys">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="key" type="key_t" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="referredSemanticId" type="globalReference_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="multiLanguageProperty">
+    <xs:sequence>
+      <xs:group ref="dataElement"/>
+      <xs:element name="value" type="langStringSet_t" minOccurs="0"/>
+      <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
   <xs:group name="operation">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
@@ -848,11 +516,6 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="operation_t">
-    <xs:sequence>
-      <xs:group ref="operation"/>
-    </xs:sequence>
-  </xs:complexType>
   <xs:group name="operationVariable">
     <xs:sequence>
       <xs:element name="value">
@@ -864,39 +527,260 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="operationVariable_t">
+  <xs:group name="property">
     <xs:sequence>
-      <xs:group ref="operationVariable"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="capability">
-    <xs:sequence>
-      <xs:group ref="submodelElement"/>
+      <xs:group ref="dataElement"/>
+      <xs:element name="valueType" type="dataTypeDefXsd_t"/>
+      <xs:element name="value" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="capability_t">
+  <xs:group name="qualifiable">
     <xs:sequence>
-      <xs:group ref="capability"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="conceptDescription">
-    <xs:sequence>
-      <xs:group ref="identifiable"/>
-      <xs:group ref="hasDataSpecification"/>
-      <xs:element name="isCaseOf" minOccurs="0">
+      <xs:element name="qualifiers" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="globalReference" type="globalReference_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="qualifier" type="qualifier_t" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="conceptDescription_t">
+  <xs:group name="qualifiable_choice">
+    <xs:choice>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="capability" type="capability_t"/>
+      <xs:element name="entity" type="entity_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="operation" type="operation_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+      <xs:element name="submodel" type="submodel_t"/>
+      <xs:element name="submodelElementList" type="submodelElementList_t"/>
+      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="qualifier">
     <xs:sequence>
-      <xs:group ref="conceptDescription"/>
+      <xs:group ref="hasSemantics"/>
+      <xs:element name="type">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="valueType" type="dataTypeDefXsd_t"/>
+      <xs:element name="value" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
     </xs:sequence>
-  </xs:complexType>
+  </xs:group>
+  <xs:group name="range">
+    <xs:sequence>
+      <xs:group ref="dataElement"/>
+      <xs:element name="valueType" type="dataTypeDefXsd_t"/>
+      <xs:element name="min" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="max" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="referable">
+    <xs:sequence>
+      <xs:group ref="hasExtensions"/>
+      <xs:element name="idShort" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:maxLength value="128"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="displayName" type="langStringSet_t" minOccurs="0"/>
+      <xs:element name="category" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="description" type="langStringSet_t" minOccurs="0"/>
+      <xs:element name="checksum" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="referable_choice">
+    <xs:choice>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+      <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t"/>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="capability" type="capability_t"/>
+      <xs:element name="conceptDescription" type="conceptDescription_t"/>
+      <xs:element name="entity" type="entity_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="operation" type="operation_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+      <xs:element name="submodel" type="submodel_t"/>
+      <xs:element name="submodelElementList" type="submodelElementList_t"/>
+      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
+      <xs:element name="view" type="view_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="reference">
+    <xs:sequence/>
+  </xs:group>
+  <xs:group name="referenceElement">
+    <xs:sequence>
+      <xs:group ref="dataElement"/>
+      <xs:element name="value" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="reference_choice"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="reference_choice">
+    <xs:choice>
+      <xs:element name="globalReference" type="globalReference_t"/>
+      <xs:element name="modelReference" type="modelReference_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="relationshipElement">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+      <xs:element name="first">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="reference_choice"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="second">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="reference_choice"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="relationshipElement_choice">
+    <xs:choice>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="resource">
+    <xs:sequence>
+      <xs:element name="path" type="assetKind_t"/>
+      <xs:element name="contentType" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="^([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*$"/>
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="submodel">
+    <xs:sequence>
+      <xs:group ref="identifiable"/>
+      <xs:group ref="hasKind"/>
+      <xs:group ref="hasSemantics"/>
+      <xs:group ref="qualifiable"/>
+      <xs:group ref="hasDataSpecification"/>
+      <xs:element name="submodelElements" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="submodelElement">
+    <xs:sequence>
+      <xs:group ref="referable"/>
+      <xs:group ref="hasKind"/>
+      <xs:group ref="hasSemantics"/>
+      <xs:group ref="qualifiable"/>
+      <xs:group ref="hasDataSpecification"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="submodelElementList">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+      <xs:element name="typeValueListElement" type="submodelElementElements_t"/>
+      <xs:element name="orderRelevant" type="xs:boolean" minOccurs="0"/>
+      <xs:element name="value" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="semanticIdListElement" type="globalReference_t" minOccurs="0"/>
+      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="submodelElementStruct">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+      <xs:element name="value" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="submodelElement_choice">
+    <xs:choice>
+      <xs:element name="annotatedRelationshipElement" type="annotatedRelationshipElement_t"/>
+      <xs:element name="basicEventElement" type="basicEventElement_t"/>
+      <xs:element name="blob" type="blob_t"/>
+      <xs:element name="capability" type="capability_t"/>
+      <xs:element name="entity" type="entity_t"/>
+      <xs:element name="file" type="file_t"/>
+      <xs:element name="multiLanguageProperty" type="multiLanguageProperty_t"/>
+      <xs:element name="operation" type="operation_t"/>
+      <xs:element name="property" type="property_t"/>
+      <xs:element name="range" type="range_t"/>
+      <xs:element name="referenceElement" type="referenceElement_t"/>
+      <xs:element name="submodelElementList" type="submodelElementList_t"/>
+      <xs:element name="submodelElementStruct" type="submodelElementStruct_t"/>
+    </xs:choice>
+  </xs:group>
   <xs:group name="view">
     <xs:sequence>
       <xs:group ref="referable"/>
@@ -911,122 +795,10 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-  <xs:complexType name="view_t">
-    <xs:sequence>
-      <xs:group ref="view"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="reference">
-    <xs:sequence/>
-  </xs:group>
-  <xs:complexType name="reference_t">
-    <xs:sequence>
-      <xs:group ref="reference"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="reference_choice">
-    <xs:choice>
-      <xs:element name="globalReference" type="globalReference_t"/>
-      <xs:element name="modelReference" type="modelReference_t"/>
-    </xs:choice>
-  </xs:group>
-  <xs:group name="globalReference">
-    <xs:sequence>
-      <xs:group ref="reference"/>
-      <xs:element name="value">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="globalReference_t">
-    <xs:sequence>
-      <xs:group ref="globalReference"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="modelReference">
-    <xs:sequence>
-      <xs:group ref="reference"/>
-      <xs:element name="keys">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="key" type="key_t" minOccurs="1" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="referredSemanticId" type="globalReference_t" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="modelReference_t">
-    <xs:sequence>
-      <xs:group ref="modelReference"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:group name="key">
-    <xs:sequence>
-      <xs:element name="type" type="keyElements_t"/>
-      <xs:element name="value">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:minLength value="1"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="key_t">
-    <xs:sequence>
-      <xs:group ref="key"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:simpleType name="submodelElementElements_t">
+  <xs:simpleType name="assetKind_t">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="AnnotatedRelationshipElement"/>
-      <xs:enumeration value="BasicEventElement"/>
-      <xs:enumeration value="Blob"/>
-      <xs:enumeration value="Capability"/>
-      <xs:enumeration value="DataElement"/>
-      <xs:enumeration value="Entity"/>
-      <xs:enumeration value="EventElement"/>
-      <xs:enumeration value="File"/>
-      <xs:enumeration value="MultiLanguageProperty"/>
-      <xs:enumeration value="Operation"/>
-      <xs:enumeration value="Property"/>
-      <xs:enumeration value="Range"/>
-      <xs:enumeration value="ReferenceElement"/>
-      <xs:enumeration value="RelationshipElement"/>
-      <xs:enumeration value="SubmodelElement"/>
-      <xs:enumeration value="SubmodelElementList"/>
-      <xs:enumeration value="SubmodelElementStruct"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="keyElements_t">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="FragmentReference"/>
-      <xs:enumeration value="GlobalReference"/>
-      <xs:enumeration value="AnnotatedRelationshipElement"/>
-      <xs:enumeration value="AssetAdministrationShell"/>
-      <xs:enumeration value="BasicEventElement"/>
-      <xs:enumeration value="Blob"/>
-      <xs:enumeration value="Capability"/>
-      <xs:enumeration value="ConceptDescription"/>
-      <xs:enumeration value="DataElement"/>
-      <xs:enumeration value="Entity"/>
-      <xs:enumeration value="EventElement"/>
-      <xs:enumeration value="File"/>
-      <xs:enumeration value="MultiLanguageProperty"/>
-      <xs:enumeration value="Operation"/>
-      <xs:enumeration value="Property"/>
-      <xs:enumeration value="Range"/>
-      <xs:enumeration value="ReferenceElement"/>
-      <xs:enumeration value="RelationshipElement"/>
-      <xs:enumeration value="Submodel"/>
-      <xs:enumeration value="SubmodelElement"/>
-      <xs:enumeration value="SubmodelElementList"/>
-      <xs:enumeration value="SubmodelElementStruct"/>
+      <xs:enumeration value="Type"/>
+      <xs:enumeration value="Instance"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="dataTypeDefXsd_t">
@@ -1066,67 +838,291 @@
       <xs:enumeration value="xs:negativeInteger"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:group name="langString">
+  <xs:simpleType name="direction_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="INPUT"/>
+      <xs:enumeration value="OUTPUT"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="entityType_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="COMANAGEDENTITY"/>
+      <xs:enumeration value="SELFMANAGEDENTITY"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="keyElements_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="FragmentReference"/>
+      <xs:enumeration value="GlobalReference"/>
+      <xs:enumeration value="AnnotatedRelationshipElement"/>
+      <xs:enumeration value="AssetAdministrationShell"/>
+      <xs:enumeration value="BasicEventElement"/>
+      <xs:enumeration value="Blob"/>
+      <xs:enumeration value="Capability"/>
+      <xs:enumeration value="ConceptDescription"/>
+      <xs:enumeration value="DataElement"/>
+      <xs:enumeration value="Entity"/>
+      <xs:enumeration value="EventElement"/>
+      <xs:enumeration value="File"/>
+      <xs:enumeration value="MultiLanguageProperty"/>
+      <xs:enumeration value="Operation"/>
+      <xs:enumeration value="Property"/>
+      <xs:enumeration value="Range"/>
+      <xs:enumeration value="ReferenceElement"/>
+      <xs:enumeration value="RelationshipElement"/>
+      <xs:enumeration value="Submodel"/>
+      <xs:enumeration value="SubmodelElement"/>
+      <xs:enumeration value="SubmodelElementList"/>
+      <xs:enumeration value="SubmodelElementStruct"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="modelingKind_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="TEMPLATE"/>
+      <xs:enumeration value="INSTANCE"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="stateOfEvent_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ON"/>
+      <xs:enumeration value="OFF"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="submodelElementElements_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="AnnotatedRelationshipElement"/>
+      <xs:enumeration value="BasicEventElement"/>
+      <xs:enumeration value="Blob"/>
+      <xs:enumeration value="Capability"/>
+      <xs:enumeration value="DataElement"/>
+      <xs:enumeration value="Entity"/>
+      <xs:enumeration value="EventElement"/>
+      <xs:enumeration value="File"/>
+      <xs:enumeration value="MultiLanguageProperty"/>
+      <xs:enumeration value="Operation"/>
+      <xs:enumeration value="Property"/>
+      <xs:enumeration value="Range"/>
+      <xs:enumeration value="ReferenceElement"/>
+      <xs:enumeration value="RelationshipElement"/>
+      <xs:enumeration value="SubmodelElement"/>
+      <xs:enumeration value="SubmodelElementList"/>
+      <xs:enumeration value="SubmodelElementStruct"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="administrativeInformation_t">
     <xs:sequence>
-      <xs:element name="language">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:pattern value="^(([a-zA-Z]{2,3}(-[a-zA-Z]{3}(-[a-zA-Z]{3}){2})?|[a-zA-Z]{4}|[a-zA-Z]{5,8})(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-(([a-zA-Z0-9]){5,8}|[0-9]([a-zA-Z0-9]){3}))*(-[0-9A-WY-Za-wy-z](-([a-zA-Z0-9]){2,8})+)*(-[xX](-([a-zA-Z0-9]){1,8})+)?|[xX](-([a-zA-Z0-9]){1,8})+|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="text" type="xs:string"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="langString_t">
-    <xs:sequence>
-      <xs:group ref="langString"/>
+      <xs:group ref="administrativeInformation"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:group name="langStringSet">
+  <xs:complexType name="annotatedRelationshipElement_t">
     <xs:sequence>
-      <xs:element name="langStrings">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:group>
-  <xs:complexType name="langStringSet_t">
-    <xs:sequence>
-      <xs:group ref="langStringSet"/>
+      <xs:group ref="annotatedRelationshipElement"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:group name="environment">
+  <xs:complexType name="assetAdministrationShell_t">
     <xs:sequence>
-      <xs:element name="assetAdministrationShells" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="submodels" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="submodel" type="submodel_t" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="conceptDescriptions" minOccurs="0">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="conceptDescription" type="conceptDescription_t" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
+      <xs:group ref="assetAdministrationShell"/>
     </xs:sequence>
-  </xs:group>
+  </xs:complexType>
+  <xs:complexType name="assetInformation_t">
+    <xs:sequence>
+      <xs:group ref="assetInformation"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="basicEventElement_t">
+    <xs:sequence>
+      <xs:group ref="basicEventElement"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="blob_t">
+    <xs:sequence>
+      <xs:group ref="blob"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="capability_t">
+    <xs:sequence>
+      <xs:group ref="capability"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="conceptDescription_t">
+    <xs:sequence>
+      <xs:group ref="conceptDescription"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dataElement_t">
+    <xs:sequence>
+      <xs:group ref="dataElement"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="entity_t">
+    <xs:sequence>
+      <xs:group ref="entity"/>
+    </xs:sequence>
+  </xs:complexType>
   <xs:complexType name="environment_t">
     <xs:sequence>
       <xs:group ref="environment"/>
     </xs:sequence>
   </xs:complexType>
+  <xs:complexType name="eventElement_t">
+    <xs:sequence>
+      <xs:group ref="eventElement"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="eventPayload_t">
+    <xs:sequence>
+      <xs:group ref="eventPayload"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="extension_t">
+    <xs:sequence>
+      <xs:group ref="extension"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="file_t">
+    <xs:sequence>
+      <xs:group ref="file"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="globalReference_t">
+    <xs:sequence>
+      <xs:group ref="globalReference"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="hasDataSpecification_t">
+    <xs:sequence>
+      <xs:group ref="hasDataSpecification"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="hasExtensions_t">
+    <xs:sequence>
+      <xs:group ref="hasExtensions"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="hasKind_t">
+    <xs:sequence>
+      <xs:group ref="hasKind"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="hasSemantics_t">
+    <xs:sequence>
+      <xs:group ref="hasSemantics"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="identifiable_t">
+    <xs:sequence>
+      <xs:group ref="identifiable"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="identifierKeyValuePair_t">
+    <xs:sequence>
+      <xs:group ref="identifierKeyValuePair"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="key_t">
+    <xs:sequence>
+      <xs:group ref="key"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="langStringSet_t">
+    <xs:sequence>
+      <xs:group ref="langStringSet"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="langString_t">
+    <xs:sequence>
+      <xs:group ref="langString"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="modelReference_t">
+    <xs:sequence>
+      <xs:group ref="modelReference"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="multiLanguageProperty_t">
+    <xs:sequence>
+      <xs:group ref="multiLanguageProperty"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="operationVariable_t">
+    <xs:sequence>
+      <xs:group ref="operationVariable"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="operation_t">
+    <xs:sequence>
+      <xs:group ref="operation"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="property_t">
+    <xs:sequence>
+      <xs:group ref="property"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="qualifiable_t">
+    <xs:sequence>
+      <xs:group ref="qualifiable"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="qualifier_t">
+    <xs:sequence>
+      <xs:group ref="qualifier"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="range_t">
+    <xs:sequence>
+      <xs:group ref="range"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referable_t">
+    <xs:sequence>
+      <xs:group ref="referable"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="referenceElement_t">
+    <xs:sequence>
+      <xs:group ref="referenceElement"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="reference_t">
+    <xs:sequence>
+      <xs:group ref="reference"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="relationshipElement_t">
+    <xs:sequence>
+      <xs:group ref="relationshipElement"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="resource_t">
+    <xs:sequence>
+      <xs:group ref="resource"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="submodelElementList_t">
+    <xs:sequence>
+      <xs:group ref="submodelElementList"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="submodelElementStruct_t">
+    <xs:sequence>
+      <xs:group ref="submodelElementStruct"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="submodelElement_t">
+    <xs:sequence>
+      <xs:group ref="submodelElement"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="submodel_t">
+    <xs:sequence>
+      <xs:group ref="submodel"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="view_t">
+    <xs:sequence>
+      <xs:group ref="view"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="environment" type="environment_t"/>
 </xs:schema>


### PR DESCRIPTION
While the order of elements in `<schema>` has no influence, we first
group them by tag, and then sort each group by `name` attribute.

This makes it easier to:
* diff,
* search, and
* compare against JSON and RDF+SHACL schemas.

The XSD has been generated by [aas-core-codegen 0.0.8] based on
[aas-core-meta 2022.4.30a5].

[aas-core-codegen 0.0.8]: https://github.com/aas-core-works/aas-core-codegen/releases/tag/v0.0.8
[aas-core-meta 2022.4.30a5]: https://github.com/aas-core-works/aas-core-meta/releases/tag/v2022.4.30a5