### PR TITLE
Update examples for ``Reference``

### DIFF
--- a/schemas/json/examples/generated/BasicEventElement/complete.json
+++ b/schemas/json/examples/generated/BasicEventElement/complete.json
@@ -52,7 +52,7 @@
                 "value": "something_random_747861e9"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_70e2a6e3"
               }
             ],
@@ -68,7 +68,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_01.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_01.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_02.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_02.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_03.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_03.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_04.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_04.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_05.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_05.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_06.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_06.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_07.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_07.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_08.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_08.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_09.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_09.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_10.json
+++ b/schemas/json/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_10.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_01.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_02.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_03.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/random_positive.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/random_positive.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_large_year.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_large_year.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.json
+++ b/schemas/json/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_01.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_02.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_03.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/random_positive.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/random_positive.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/very_large_year.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/very_large_year.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.json
+++ b/schemas/json/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_01.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_01.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_02.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_02.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_03.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_03.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/random_positive.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/random_positive.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/very_large_year.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/very_large_year.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.json
+++ b/schemas/json/examples/generated/BasicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.json
@@ -16,7 +16,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/BasicEventElement/minimal.json
+++ b/schemas/json/examples/generated/BasicEventElement/minimal.json
@@ -15,7 +15,7 @@
                 "value": "something_random_d041916a"
               },
               {
-                "type": "Referable",
+                "type": "Blob",
                 "value": "something_random_c0f0d84b"
               }
             ],

--- a/schemas/json/examples/generated/Reference/complete.json
+++ b/schemas/json/examples/generated/Reference/complete.json
@@ -1,20 +1,26 @@
 {
-  "assetAdministrationShells": [
+  "submodels": [
     {
-      "assetInformation": {
-        "assetKind": "Instance"
-      },
-      "derivedFrom": {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
         "keys": [
           {
-            "type": "AssetAdministrationShell",
-            "value": "44e7dc4a"
+            "type": "GlobalReference",
+            "value": "something_random_920ea681"
           }
         ],
-        "type": "ModelReference"
-      },
-      "id": "something_random_428f0205",
-      "modelType": "AssetAdministrationShell"
+        "referredSemanticId": {
+          "keys": [
+            {
+              "type": "GlobalReference",
+              "value": "something_random_01ef5a5b"
+            }
+          ],
+          "type": "GlobalReference"
+        },
+        "type": "GlobalReference"
+      }
     }
   ]
 }

--- a/schemas/json/examples/generated/Reference/for_a_global_reference_first_key_in_generic_globally_identifiables.json
+++ b/schemas/json/examples/generated/Reference/for_a_global_reference_first_key_in_generic_globally_identifiables.json
@@ -7,7 +7,7 @@
         "keys": [
           {
             "type": "GlobalReference",
-            "value": "something_random_920ea681"
+            "value": "something"
           }
         ],
         "type": "GlobalReference"

--- a/schemas/json/examples/generated/Reference/for_a_global_reference_last_key_in_generic_fragment_keys.json
+++ b/schemas/json/examples/generated/Reference/for_a_global_reference_last_key_in_generic_fragment_keys.json
@@ -7,7 +7,11 @@
         "keys": [
           {
             "type": "GlobalReference",
-            "value": "something_random_920ea681"
+            "value": "something"
+          },
+          {
+            "type": "FragmentReference",
+            "value": "something_more"
           }
         ],
         "type": "GlobalReference"

--- a/schemas/json/examples/generated/Reference/for_a_global_reference_last_key_in_generic_globally_identifiable.json
+++ b/schemas/json/examples/generated/Reference/for_a_global_reference_last_key_in_generic_globally_identifiable.json
@@ -7,7 +7,11 @@
         "keys": [
           {
             "type": "GlobalReference",
-            "value": "something_random_920ea681"
+            "value": "something"
+          },
+          {
+            "type": "GlobalReference",
+            "value": "something_more"
           }
         ],
         "type": "GlobalReference"

--- a/schemas/json/examples/generated/Reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.json
+++ b/schemas/json/examples/generated/Reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.json
@@ -6,11 +6,11 @@
       "semanticId": {
         "keys": [
           {
-            "type": "GlobalReference",
-            "value": "something_random_920ea681"
+            "type": "Submodel",
+            "value": "something"
           }
         ],
-        "type": "GlobalReference"
+        "type": "ModelReference"
       }
     }
   ]

--- a/schemas/json/examples/generated/Reference/for_a_model_reference_fragment_after_blob.json
+++ b/schemas/json/examples/generated/Reference/for_a_model_reference_fragment_after_blob.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "Blob",
+            "value": "something_more"
+          },
+          {
+            "type": "FragmentReference",
+            "value": "yet_something_more"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/schemas/json/examples/generated/Reference/for_a_model_reference_valid_key_value_after_submodel_element_list.json
+++ b/schemas/json/examples/generated/Reference/for_a_model_reference_valid_key_value_after_submodel_element_list.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "some_submodel",
+      "modelType": "Submodel",
+      "semanticId": {
+        "keys": [
+          {
+            "type": "Submodel",
+            "value": "something"
+          },
+          {
+            "type": "SubmodelElementList",
+            "value": "something_more"
+          },
+          {
+            "type": "Property",
+            "value": "123"
+          }
+        ],
+        "type": "ModelReference"
+      }
+    }
+  ]
+}

--- a/schemas/xml/examples/generated/basicEventElement/complete.xml
+++ b/schemas/xml/examples/generated/basicEventElement/complete.xml
@@ -75,7 +75,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>
@@ -91,7 +91,7 @@
 								<value>something_random_747861e9</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_70e2a6e3</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_04.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_05.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_06.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_07.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_08.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_09.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_10.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/random_positive.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/random_positive.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_large_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_large_year.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/midnight_with_24_hours.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/midnight_with_zeros.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/random_positive.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/random_positive.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/very_large_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/very_large_year.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/very_long_fractional_second.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_01.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_02.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_03.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/midnight_with_24_hours.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/midnight_with_zeros.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/random_positive.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/random_positive.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/very_large_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/very_large_year.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/very_long_fractional_second.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/basicEventElement/minimal.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minimal.xml
@@ -13,7 +13,7 @@
 								<value>something_random_d041916a</value>
 							</key>
 							<key>
-								<type>Referable</type>
+								<type>Blob</type>
 								<value>something_random_c0f0d84b</value>
 							</key>
 						</keys>

--- a/schemas/xml/examples/generated/reference/for_a_global_reference_first_key_in_generic_globally_identifiables.xml
+++ b/schemas/xml/examples/generated/reference/for_a_global_reference_first_key_in_generic_globally_identifiables.xml
@@ -4,19 +4,10 @@
 			<id>some_submodel</id>
 			<semanticId>
 				<type>GlobalReference</type>
-				<referredSemanticId>
-					<type>GlobalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>something_random_01ef5a5b</value>
-						</key>
-					</keys>
-				</referredSemanticId>
 				<keys>
 					<key>
 						<type>GlobalReference</type>
-						<value>something_random_920ea681</value>
+						<value>something</value>
 					</key>
 				</keys>
 			</semanticId>

--- a/schemas/xml/examples/generated/reference/for_a_global_reference_last_key_in_generic_fragment_keys.xml
+++ b/schemas/xml/examples/generated/reference/for_a_global_reference_last_key_in_generic_fragment_keys.xml
@@ -4,19 +4,14 @@
 			<id>some_submodel</id>
 			<semanticId>
 				<type>GlobalReference</type>
-				<referredSemanticId>
-					<type>GlobalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>something_random_01ef5a5b</value>
-						</key>
-					</keys>
-				</referredSemanticId>
 				<keys>
 					<key>
 						<type>GlobalReference</type>
-						<value>something_random_920ea681</value>
+						<value>something</value>
+					</key>
+					<key>
+						<type>FragmentReference</type>
+						<value>something_more</value>
 					</key>
 				</keys>
 			</semanticId>

--- a/schemas/xml/examples/generated/reference/for_a_global_reference_last_key_in_generic_globally_identifiable.xml
+++ b/schemas/xml/examples/generated/reference/for_a_global_reference_last_key_in_generic_globally_identifiable.xml
@@ -4,19 +4,14 @@
 			<id>some_submodel</id>
 			<semanticId>
 				<type>GlobalReference</type>
-				<referredSemanticId>
-					<type>GlobalReference</type>
-					<keys>
-						<key>
-							<type>GlobalReference</type>
-							<value>something_random_01ef5a5b</value>
-						</key>
-					</keys>
-				</referredSemanticId>
 				<keys>
 					<key>
 						<type>GlobalReference</type>
-						<value>something_random_920ea681</value>
+						<value>something</value>
+					</key>
+					<key>
+						<type>GlobalReference</type>
+						<value>something_more</value>
 					</key>
 				</keys>
 			</semanticId>

--- a/schemas/xml/examples/generated/reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.xml
+++ b/schemas/xml/examples/generated/reference/for_a_model_reference_first_key_in_globally_and_aas_identifiables.xml
@@ -3,11 +3,11 @@
 		<submodel>
 			<id>some_submodel</id>
 			<semanticId>
-				<type>GlobalReference</type>
+				<type>ModelReference</type>
 				<keys>
 					<key>
-						<type>GlobalReference</type>
-						<value>something_random_920ea681</value>
+						<type>Submodel</type>
+						<value>something</value>
 					</key>
 				</keys>
 			</semanticId>

--- a/schemas/xml/examples/generated/reference/for_a_model_reference_fragment_after_blob.xml
+++ b/schemas/xml/examples/generated/reference/for_a_model_reference_fragment_after_blob.xml
@@ -1,0 +1,24 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>Blob</type>
+						<value>something_more</value>
+					</key>
+					<key>
+						<type>FragmentReference</type>
+						<value>yet_something_more</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>

--- a/schemas/xml/examples/generated/reference/for_a_model_reference_valid_key_value_after_submodel_element_list.xml
+++ b/schemas/xml/examples/generated/reference/for_a_model_reference_valid_key_value_after_submodel_element_list.xml
@@ -1,0 +1,24 @@
+<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
+	<submodels>
+		<submodel>
+			<id>some_submodel</id>
+			<semanticId>
+				<type>ModelReference</type>
+				<keys>
+					<key>
+						<type>Submodel</type>
+						<value>something</value>
+					</key>
+					<key>
+						<type>SubmodelElementList</type>
+						<value>something_more</value>
+					</key>
+					<key>
+						<type>Property</type>
+						<value>123</value>
+					</key>
+				</keys>
+			</semanticId>
+		</submodel>
+	</submodels>
+</environment>


### PR DESCRIPTION
We had to update examples for the class ``Reference`` as the
implementation of constraints AASd-121 to 128 in aas-core-meta and
aas-core-codegen revelead multiple fallacies in the test data.

These examples are based on:

* [aas-core-meta ed81978],
* [aas-core-codegen b944996], and
* [aas-core3.0rc02-testgen 63f89db8]

[aas-core-meta ed81978]: https://github.com/aas-core-works/aas-core-meta/commit/ed81978
[aas-core-codegen b944996]: https://github.com/aas-core-works/aas-core-codegen/commit/b944996
[aas-core3.0rc02-testgen 63f89db8]: https://github.com/aas-core-works/aas-core3.0rc02-testgen/commit/63f89db8