### PR TITLE
Make ``xs:`` prefix consistent in XSD/RDF/SHACL (#260)

### DIFF
--- a/schemas/rdf/rdf-ontology.ttl
+++ b/schemas/rdf/rdf-ontology.ttl
@@ -2,7 +2,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
 @base <http://www.admin-shell.io/aas/3/0/RC02/> .
 
 <http://www.admin-shell.io/aas/3/0/RC02/> rdf:type owl:Ontology ;
@@ -13,7 +13,7 @@
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements
 aas:AasSubmodelElements rdf:type owl:Class ;
-    rdfs:label "Aas Submodel Elements"^^xsd:string ;
+    rdfs:label "Aas Submodel Elements"^^xs:string ;
     rdfs:comment "Enumeration of all possible elements of a 'SubmodelElementList'."@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/AnnotatedRelationshipElement>
@@ -38,122 +38,122 @@ aas:AasSubmodelElements rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/AnnotatedRelationshipElement
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/AnnotatedRelationshipElement> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Annotated Relationship Element"^^xsd:string ;
+    rdfs:label "Annotated Relationship Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/BasicEventElement
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/BasicEventElement> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Basic Event Element"^^xsd:string ;
+    rdfs:label "Basic Event Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Blob
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Blob> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Blob"^^xsd:string ;
+    rdfs:label "Blob"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Capability
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Capability> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Capability"^^xsd:string ;
+    rdfs:label "Capability"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/DataElement
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/DataElement> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Data Element"^^xsd:string ;
+    rdfs:label "Data Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Entity
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Entity> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Entity"^^xsd:string ;
+    rdfs:label "Entity"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/EventElement
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/EventElement> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Event Element"^^xsd:string ;
+    rdfs:label "Event Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/File
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/File> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "File"^^xsd:string ;
+    rdfs:label "File"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/MultiLanguageProperty
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/MultiLanguageProperty> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Multi Language Property"^^xsd:string ;
+    rdfs:label "Multi Language Property"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Operation
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Operation> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Operation"^^xsd:string ;
+    rdfs:label "Operation"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Property
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Property> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Property"^^xsd:string ;
+    rdfs:label "Property"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Range
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/Range> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Range"^^xsd:string ;
+    rdfs:label "Range"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/ReferenceElement
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/ReferenceElement> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Reference Element"^^xsd:string ;
+    rdfs:label "Reference Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/RelationshipElement
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/RelationshipElement> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Relationship Element"^^xsd:string ;
+    rdfs:label "Relationship Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/SubmodelElement
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/SubmodelElement> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Submodel Element"^^xsd:string ;
+    rdfs:label "Submodel Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/SubmodelElementCollection
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/SubmodelElementCollection> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Submodel Element Collection"^^xsd:string ;
+    rdfs:label "Submodel Element Collection"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/SubmodelElementList
 <http://www.admin-shell.io/aas/3/0/RC02/AasSubmodelElements/SubmodelElementList> rdf:type aas:AasSubmodelElements ;
-    rdfs:label "Submodel Element List"^^xsd:string ;
+    rdfs:label "Submodel Element List"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AdministrativeInformation
 aas:AdministrativeInformation rdf:type owl:Class ;
     rdfs:subClassOf aas:HasDataSpecification ;
-    rdfs:label "Administrative Information"^^xsd:string ;
+    rdfs:label "Administrative Information"^^xs:string ;
     rdfs:comment "Administrative meta-information for an element like version information."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AdministrativeInformation/revision
 <http://www.admin-shell.io/aas/3/0/RC02/AdministrativeInformation/revision> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has revision"^^xsd:string ;
+    rdfs:label "has revision"^^xs:string ;
     rdfs:domain aas:AdministrativeInformation ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Revision of the element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AdministrativeInformation/version
 <http://www.admin-shell.io/aas/3/0/RC02/AdministrativeInformation/version> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has version"^^xsd:string ;
+    rdfs:label "has version"^^xs:string ;
     rdfs:domain aas:AdministrativeInformation ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Version of the element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AnnotatedRelationshipElement
 aas:AnnotatedRelationshipElement rdf:type owl:Class ;
     rdfs:subClassOf aas:RelationshipElement ;
-    rdfs:label "Annotated Relationship Element"^^xsd:string ;
+    rdfs:label "Annotated Relationship Element"^^xs:string ;
     rdfs:comment "An annotated relationship element is a relationship element that can be annotated with additional data elements."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AnnotatedRelationshipElement/annotations
 <http://www.admin-shell.io/aas/3/0/RC02/AnnotatedRelationshipElement/annotations> rdf:type owl:ObjectProperty ;
-    rdfs:label "has annotations"^^xsd:string ;
+    rdfs:label "has annotations"^^xs:string ;
     rdfs:domain aas:AnnotatedRelationshipElement ;
     rdfs:range aas:DataElement ;
     rdfs:comment "A data element that represents an annotation that holds for the relationship between the two elements"@en ;
@@ -163,13 +163,13 @@ aas:AnnotatedRelationshipElement rdf:type owl:Class ;
 aas:AssetAdministrationShell rdf:type owl:Class ;
     rdfs:subClassOf aas:Identifiable ;
     rdfs:subClassOf aas:HasDataSpecification ;
-    rdfs:label "Asset Administration Shell"^^xsd:string ;
+    rdfs:label "Asset Administration Shell"^^xs:string ;
     rdfs:comment "An asset administration shell."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation
 <http://www.admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> rdf:type owl:ObjectProperty ;
-    rdfs:label "has asset information"^^xsd:string ;
+    rdfs:label "has asset information"^^xs:string ;
     rdfs:domain aas:AssetAdministrationShell ;
     rdfs:range aas:AssetInformation ;
     rdfs:comment "Meta-information about the asset the AAS is representing."@en ;
@@ -177,7 +177,7 @@ aas:AssetAdministrationShell rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/derivedFrom
 <http://www.admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/derivedFrom> rdf:type owl:ObjectProperty ;
-    rdfs:label "has derived from"^^xsd:string ;
+    rdfs:label "has derived from"^^xs:string ;
     rdfs:domain aas:AssetAdministrationShell ;
     rdfs:range aas:Reference ;
     rdfs:comment "The reference to the AAS the AAS was derived from."@en ;
@@ -185,7 +185,7 @@ aas:AssetAdministrationShell rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/submodels
 <http://www.admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/submodels> rdf:type owl:ObjectProperty ;
-    rdfs:label "has submodels"^^xsd:string ;
+    rdfs:label "has submodels"^^xs:string ;
     rdfs:domain aas:AssetAdministrationShell ;
     rdfs:range aas:Reference ;
     rdfs:comment "References to submodels of the AAS."@en ;
@@ -193,13 +193,13 @@ aas:AssetAdministrationShell rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetInformation
 aas:AssetInformation rdf:type owl:Class ;
-    rdfs:label "Asset Information"^^xsd:string ;
+    rdfs:label "Asset Information"^^xs:string ;
     rdfs:comment "In 'AssetInformation' identifying meta data of the asset that is represented by an AAS is defined."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind
 <http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> rdf:type owl:ObjectProperty ;
-    rdfs:label "has asset kind"^^xsd:string ;
+    rdfs:label "has asset kind"^^xs:string ;
     rdfs:domain aas:AssetInformation ;
     rdfs:range aas:AssetKind ;
     rdfs:comment "Denotes whether the Asset is of kind 'Type' or 'Instance'."@en ;
@@ -207,7 +207,7 @@ aas:AssetInformation rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/defaultThumbnail
 <http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/defaultThumbnail> rdf:type owl:ObjectProperty ;
-    rdfs:label "has default thumbnail"^^xsd:string ;
+    rdfs:label "has default thumbnail"^^xs:string ;
     rdfs:domain aas:AssetInformation ;
     rdfs:range aas:Resource ;
     rdfs:comment "Thumbnail of the asset represented by the Asset Administration Shell."@en ;
@@ -215,7 +215,7 @@ aas:AssetInformation rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/globalAssetId
 <http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/globalAssetId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has global asset id"^^xsd:string ;
+    rdfs:label "has global asset id"^^xs:string ;
     rdfs:domain aas:AssetInformation ;
     rdfs:range aas:Reference ;
     rdfs:comment "Global identifier of the asset the AAS is representing."@en ;
@@ -223,7 +223,7 @@ aas:AssetInformation rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/specificAssetIds
 <http://www.admin-shell.io/aas/3/0/RC02/AssetInformation/specificAssetIds> rdf:type owl:ObjectProperty ;
-    rdfs:label "has specific asset ids"^^xsd:string ;
+    rdfs:label "has specific asset ids"^^xs:string ;
     rdfs:domain aas:AssetInformation ;
     rdfs:range aas:SpecificAssetId ;
     rdfs:comment "Additional domain-specific, typically proprietary identifier for the asset like e.g., serial number etc."@en ;
@@ -231,7 +231,7 @@ aas:AssetInformation rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetKind
 aas:AssetKind rdf:type owl:Class ;
-    rdfs:label "Asset Kind"^^xsd:string ;
+    rdfs:label "Asset Kind"^^xs:string ;
     rdfs:comment "Enumeration for denoting whether an asset is a type asset or an instance asset."@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/AssetKind/Instance>
@@ -241,26 +241,26 @@ aas:AssetKind rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetKind/Instance
 <http://www.admin-shell.io/aas/3/0/RC02/AssetKind/Instance> rdf:type aas:AssetKind ;
-    rdfs:label "Instance"^^xsd:string ;
+    rdfs:label "Instance"^^xs:string ;
     rdfs:comment "concrete, clearly identifiable component of a certain type"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/AssetKind/Type
 <http://www.admin-shell.io/aas/3/0/RC02/AssetKind/Type> rdf:type aas:AssetKind ;
-    rdfs:label "Type"^^xsd:string ;
+    rdfs:label "Type"^^xs:string ;
     rdfs:comment "hardware or software element which specifies the common attributes shared by all instances of the type"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement
 aas:BasicEventElement rdf:type owl:Class ;
     rdfs:subClassOf aas:EventElement ;
-    rdfs:label "Basic Event Element"^^xsd:string ;
+    rdfs:label "Basic Event Element"^^xs:string ;
     rdfs:comment "A basic event element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/direction
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/direction> rdf:type owl:ObjectProperty ;
-    rdfs:label "has direction"^^xsd:string ;
+    rdfs:label "has direction"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
     rdfs:range aas:Direction ;
     rdfs:comment "Direction of event."@en ;
@@ -268,23 +268,23 @@ aas:BasicEventElement rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/lastUpdate
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/lastUpdate> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has last update"^^xsd:string ;
+    rdfs:label "has last update"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Timestamp in UTC, when the last event was received (input direction) or sent (output direction)."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/maxInterval
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/maxInterval> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has max interval"^^xsd:string ;
+    rdfs:label "has max interval"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "For input direction: not applicable."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/messageBroker
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/messageBroker> rdf:type owl:ObjectProperty ;
-    rdfs:label "has message broker"^^xsd:string ;
+    rdfs:label "has message broker"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
     rdfs:range aas:Reference ;
     rdfs:comment "Information, which outer message infrastructure shall handle messages for the 'EventElement'. Refers to a 'Submodel', 'SubmodelElementList', 'SubmodelElementCollection' or 'Entity', which contains 'DataElement''s describing the proprietary specification for the message broker."@en ;
@@ -292,23 +292,23 @@ aas:BasicEventElement rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/messageTopic
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/messageTopic> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has message topic"^^xsd:string ;
+    rdfs:label "has message topic"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Information for the outer message infrastructure for scheduling the event to the respective communication channel."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/minInterval
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/minInterval> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has min interval"^^xsd:string ;
+    rdfs:label "has min interval"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "For input direction, reports on the maximum frequency, the software entity behind the respective Referable can handle input events."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/observed
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/observed> rdf:type owl:ObjectProperty ;
-    rdfs:label "has observed"^^xsd:string ;
+    rdfs:label "has observed"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the 'Referable', which defines the scope of the event. Can be 'AssetAdministrationShell', 'Submodel', or 'SubmodelElement'."@en ;
@@ -316,7 +316,7 @@ aas:BasicEventElement rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/state
 <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/state> rdf:type owl:ObjectProperty ;
-    rdfs:label "has state"^^xsd:string ;
+    rdfs:label "has state"^^xs:string ;
     rdfs:domain aas:BasicEventElement ;
     rdfs:range aas:StateOfEvent ;
     rdfs:comment "State of event."@en ;
@@ -325,30 +325,30 @@ aas:BasicEventElement rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/Blob
 aas:Blob rdf:type owl:Class ;
     rdfs:subClassOf aas:DataElement ;
-    rdfs:label "Blob"^^xsd:string ;
+    rdfs:label "Blob"^^xs:string ;
     rdfs:comment "A 'Blob' is a data element that represents a file that is contained with its source code in the value attribute."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Blob/contentType
 <http://www.admin-shell.io/aas/3/0/RC02/Blob/contentType> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has content type"^^xsd:string ;
+    rdfs:label "has content type"^^xs:string ;
     rdfs:domain aas:Blob ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Content type of the content of the 'Blob'."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Blob/value
 <http://www.admin-shell.io/aas/3/0/RC02/Blob/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Blob ;
-    rdfs:range xsd:byte ;
+    rdfs:range xs:byte ;
     rdfs:comment "The value of the 'Blob' instance of a blob data element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Capability
 aas:Capability rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Capability"^^xsd:string ;
+    rdfs:label "Capability"^^xs:string ;
     rdfs:comment "A capability is the implementation-independent description of the potential of an asset to achieve a certain effect in the physical or virtual world."@en ;
 .
 
@@ -356,13 +356,13 @@ aas:Capability rdf:type owl:Class ;
 aas:ConceptDescription rdf:type owl:Class ;
     rdfs:subClassOf aas:Identifiable ;
     rdfs:subClassOf aas:HasDataSpecification ;
-    rdfs:label "Concept Description"^^xsd:string ;
+    rdfs:label "Concept Description"^^xs:string ;
     rdfs:comment "The semantics of a property or other elements that may have a semantic description is defined by a concept description."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ConceptDescription/isCaseOf
 <http://www.admin-shell.io/aas/3/0/RC02/ConceptDescription/isCaseOf> rdf:type owl:ObjectProperty ;
-    rdfs:label "has is case of"^^xsd:string ;
+    rdfs:label "has is case of"^^xs:string ;
     rdfs:domain aas:ConceptDescription ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to an external definition the concept is compatible to or was derived from."@en ;
@@ -371,26 +371,26 @@ aas:ConceptDescription rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataElement
 aas:DataElement rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Data Element"^^xsd:string ;
+    rdfs:label "Data Element"^^xs:string ;
     rdfs:comment "A data element is a submodel element that is not further composed out of other submodel elements."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationContent
 aas:DataSpecificationContent rdf:type owl:Class ;
-    rdfs:label "Data Specification Content"^^xsd:string ;
+    rdfs:label "Data Specification Content"^^xs:string ;
     rdfs:comment "Data specification content is part of a data specification template and defines which additional attributes shall be added to the element instance that references the data specification template and meta information about the template itself."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360
 aas:DataSpecificationIEC61360 rdf:type owl:Class ;
     rdfs:subClassOf aas:DataSpecificationContent ;
-    rdfs:label "Data Specification IEC 61360"^^xsd:string ;
+    rdfs:label "Data Specification IEC 61360"^^xs:string ;
     rdfs:comment "Content of data specification template for concept descriptions for properties, values and value lists conformant to IEC 61360."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/dataType
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/dataType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has data type"^^xsd:string ;
+    rdfs:label "has data type"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range aas:DataTypeIEC61360 ;
     rdfs:comment "Data Type"@en ;
@@ -398,7 +398,7 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/definition
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/definition> rdf:type owl:ObjectProperty ;
-    rdfs:label "has definition"^^xsd:string ;
+    rdfs:label "has definition"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range aas:LangString ;
     rdfs:comment "Definition in different languages"@en ;
@@ -406,7 +406,7 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/levelType
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/levelType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has level type"^^xsd:string ;
+    rdfs:label "has level type"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range aas:LevelType ;
     rdfs:comment "Set of levels."@en ;
@@ -414,7 +414,7 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/preferredName
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/preferredName> rdf:type owl:ObjectProperty ;
-    rdfs:label "has preferred name"^^xsd:string ;
+    rdfs:label "has preferred name"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range aas:LangString ;
     rdfs:comment "Preferred name"@en ;
@@ -422,7 +422,7 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/shortName
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/shortName> rdf:type owl:ObjectProperty ;
-    rdfs:label "has short name"^^xsd:string ;
+    rdfs:label "has short name"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range aas:LangString ;
     rdfs:comment "Short name"@en ;
@@ -430,31 +430,31 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/sourceOfDefinition
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has source of definition"^^xsd:string ;
+    rdfs:label "has source of definition"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Source of definition"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/symbol
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/symbol> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has symbol"^^xsd:string ;
+    rdfs:label "has symbol"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Symbol"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unit
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unit> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has unit"^^xsd:string ;
+    rdfs:label "has unit"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Unit"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unitId
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unitId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has unit id"^^xsd:string ;
+    rdfs:label "has unit id"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range aas:Reference ;
     rdfs:comment "Unique unit id"@en ;
@@ -462,23 +462,23 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/value
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Value"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueFormat
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueFormat> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value format"^^xsd:string ;
+    rdfs:label "has value format"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Value Format"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueList
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueList> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value list"^^xsd:string ;
+    rdfs:label "has value list"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range aas:ValueList ;
     rdfs:comment "List of allowed values"@en ;
@@ -487,20 +487,20 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit
 aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
     rdfs:subClassOf aas:DataSpecificationContent ;
-    rdfs:label "Data Specification Physical Unit"^^xsd:string ;
+    rdfs:label "Data Specification Physical Unit"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/conversionFactor
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/conversionFactor> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has conversion factor"^^xsd:string ;
+    rdfs:label "has conversion factor"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Conversion factor"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/definition
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/definition> rdf:type owl:ObjectProperty ;
-    rdfs:label "has definition"^^xsd:string ;
+    rdfs:label "has definition"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
     rdfs:range aas:LangString ;
     rdfs:comment "Definition in different languages"@en ;
@@ -508,95 +508,95 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has din notation"^^xsd:string ;
+    rdfs:label "has din notation"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Notation of physical unit conformant to DIN"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has ece code"^^xsd:string ;
+    rdfs:label "has ece code"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Code of physical unit conformant to ECE"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has ece name"^^xsd:string ;
+    rdfs:label "has ece name"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Name of physical unit conformant to ECE"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has nist name"^^xsd:string ;
+    rdfs:label "has nist name"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Name of NIST physical unit"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/registrationAuthorityId
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/registrationAuthorityId> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has registration authority id"^^xsd:string ;
+    rdfs:label "has registration authority id"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Registration authority ID"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has si name"^^xsd:string ;
+    rdfs:label "has si name"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Name of SI physical unit"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has si notation"^^xsd:string ;
+    rdfs:label "has si notation"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Notation of SI physical unit"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/sourceOfDefinition
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has source of definition"^^xsd:string ;
+    rdfs:label "has source of definition"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Source of definition"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/supplier
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/supplier> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has supplier"^^xsd:string ;
+    rdfs:label "has supplier"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Supplier"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitName
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has unit name"^^xsd:string ;
+    rdfs:label "has unit name"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Name of the physical unit"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitSymbol
 <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitSymbol> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has unit symbol"^^xsd:string ;
+    rdfs:label "has unit symbol"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Symbol for the physical unit"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd
 aas:DataTypeDefXsd rdf:type owl:Class ;
-    rdfs:label "Data Type Def Xsd"^^xsd:string ;
+    rdfs:label "Data Type Def Xsd"^^xs:string ;
     rdfs:comment "Enumeration listing all xsd anySimpleTypes"@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri>
@@ -637,172 +637,172 @@ aas:DataTypeDefXsd rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Any Uri"^^xsd:string ;
+    rdfs:label "Any Uri"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Base64Binary
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Base64Binary> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Base 64 Binary"^^xsd:string ;
+    rdfs:label "Base 64 Binary"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Boolean
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Boolean> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Boolean"^^xsd:string ;
+    rdfs:label "Boolean"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Byte
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Byte> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Byte"^^xsd:string ;
+    rdfs:label "Byte"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Date"^^xsd:string ;
+    rdfs:label "Date"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Date Time"^^xsd:string ;
+    rdfs:label "Date Time"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Date Time Stamp"^^xsd:string ;
+    rdfs:label "Date Time Stamp"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DayTimeDuration
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DayTimeDuration> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Day Time Duration"^^xsd:string ;
+    rdfs:label "Day Time Duration"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Decimal
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Decimal> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Decimal"^^xsd:string ;
+    rdfs:label "Decimal"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Double
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Double> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Double"^^xsd:string ;
+    rdfs:label "Double"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Duration
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Duration> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Duration"^^xsd:string ;
+    rdfs:label "Duration"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Float
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Float> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Float"^^xsd:string ;
+    rdfs:label "Float"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GDay
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GDay> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "G Day"^^xsd:string ;
+    rdfs:label "G Day"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonth
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonth> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "G Month"^^xsd:string ;
+    rdfs:label "G Month"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonthDay
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonthDay> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "G Month Day"^^xsd:string ;
+    rdfs:label "G Month Day"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYear
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYear> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "G Year"^^xsd:string ;
+    rdfs:label "G Year"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYearMonth
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYearMonth> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "G Year Month"^^xsd:string ;
+    rdfs:label "G Year Month"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/HexBinary
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/HexBinary> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Hex Binary"^^xsd:string ;
+    rdfs:label "Hex Binary"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Int
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Int> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Int"^^xsd:string ;
+    rdfs:label "Int"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Integer
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Integer> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Integer"^^xsd:string ;
+    rdfs:label "Integer"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Long
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Long> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Long"^^xsd:string ;
+    rdfs:label "Long"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NegativeInteger
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NegativeInteger> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Negative Integer"^^xsd:string ;
+    rdfs:label "Negative Integer"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonNegativeInteger
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonNegativeInteger> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Non Negative Integer"^^xsd:string ;
+    rdfs:label "Non Negative Integer"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonPositiveInteger
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonPositiveInteger> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Non Positive Integer"^^xsd:string ;
+    rdfs:label "Non Positive Integer"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/PositiveInteger
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/PositiveInteger> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Positive Integer"^^xsd:string ;
+    rdfs:label "Positive Integer"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Short
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Short> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Short"^^xsd:string ;
+    rdfs:label "Short"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/String
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/String> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "String"^^xsd:string ;
+    rdfs:label "String"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Time
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Time> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Time"^^xsd:string ;
+    rdfs:label "Time"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedByte
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedByte> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Unsigned Byte"^^xsd:string ;
+    rdfs:label "Unsigned Byte"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedInt
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedInt> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Unsigned Int"^^xsd:string ;
+    rdfs:label "Unsigned Int"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedLong
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedLong> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Unsigned Long"^^xsd:string ;
+    rdfs:label "Unsigned Long"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedShort
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedShort> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Unsigned Short"^^xsd:string ;
+    rdfs:label "Unsigned Short"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/YearMonthDuration
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/YearMonthDuration> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Year Month Duration"^^xsd:string ;
+    rdfs:label "Year Month Duration"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360
 aas:DataTypeIEC61360 rdf:type owl:Class ;
-    rdfs:label "Data Type IEC 61360"^^xsd:string ;
+    rdfs:label "Data Type IEC 61360"^^xs:string ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Blob>
         <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Boolean>
@@ -828,121 +828,121 @@ aas:DataTypeIEC61360 rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Blob
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Blob> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Blob"^^xsd:string ;
+    rdfs:label "Blob"^^xs:string ;
     rdfs:comment "values containing the content of a file. Values may be binaries."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Boolean
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Boolean> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Boolean"^^xsd:string ;
+    rdfs:label "Boolean"^^xs:string ;
     rdfs:comment "values representing truth of logic or Boolean algebra (TRUE, FALSE)"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Date
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Date> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Date"^^xsd:string ;
+    rdfs:label "Date"^^xs:string ;
     rdfs:comment "values containing a calendar date, conformant to ISO 8601:2004 Format yyyy-mm-dd Example from IEC 61360-1:2017: \"1999-05-31\" is the [DATE] representation of: \"31 May 1999\"."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/File
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/File> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "File"^^xsd:string ;
+    rdfs:label "File"^^xs:string ;
     rdfs:comment "values containing an address to a file. The values are of type URI and can represent an absolute or relative path."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Html
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Html> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Html"^^xsd:string ;
+    rdfs:label "Html"^^xs:string ;
     rdfs:comment "Values containing string with any sequence of characters, using the syntax of HTML5 (see W3C Recommendation 28:2014)"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCount
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCount> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Integer Count"^^xsd:string ;
+    rdfs:label "Integer Count"^^xs:string ;
     rdfs:comment "values containing values of type INTEGER but are no currencies or measures"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCurrency
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCurrency> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Integer Currency"^^xsd:string ;
+    rdfs:label "Integer Currency"^^xs:string ;
     rdfs:comment "values containing values of type INTEGER that are currencies"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerMeasure
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerMeasure> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Integer Measure"^^xsd:string ;
+    rdfs:label "Integer Measure"^^xs:string ;
     rdfs:comment "values containing values that are measure of type INTEGER. In addition such a value comes with a physical unit."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Irdi
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Irdi> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "IRDI"^^xsd:string ;
+    rdfs:label "IRDI"^^xs:string ;
     rdfs:comment "values conforming to ISO/IEC 11179 series global identifier sequences"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Iri
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Iri> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "IRI"^^xsd:string ;
+    rdfs:label "IRI"^^xs:string ;
     rdfs:comment "values containing values of type STRING conformant to Rfc 3987"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Rational
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Rational> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Rational"^^xsd:string ;
+    rdfs:label "Rational"^^xs:string ;
     rdfs:comment "values containing values of type rational"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RationalMeasure
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RationalMeasure> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Rational Measure"^^xsd:string ;
+    rdfs:label "Rational Measure"^^xs:string ;
     rdfs:comment "values containing values of type rational. In addition such a value comes with a physical unit."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCount
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCount> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Real Count"^^xsd:string ;
+    rdfs:label "Real Count"^^xs:string ;
     rdfs:comment "values containing numbers that can be written as a terminating or non-terminating decimal; a rational or irrational number but are no currencies or measures"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCurrency
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCurrency> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Real Currency"^^xsd:string ;
+    rdfs:label "Real Currency"^^xs:string ;
     rdfs:comment "values containing values of type REAL that are currencies"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealMeasure
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealMeasure> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Real Measure"^^xsd:string ;
+    rdfs:label "Real Measure"^^xs:string ;
     rdfs:comment "values containing values that are measures of type REAL. In addition such a value comes with a physical unit."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/String
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/String> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "String"^^xsd:string ;
+    rdfs:label "String"^^xs:string ;
     rdfs:comment "values consisting of sequence of characters but cannot be translated into other languages"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/StringTranslatable
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/StringTranslatable> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "String Translatable"^^xsd:string ;
+    rdfs:label "String Translatable"^^xs:string ;
     rdfs:comment "values containing string but shall be represented as different string in different languages"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Time
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Time> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Time"^^xsd:string ;
+    rdfs:label "Time"^^xs:string ;
     rdfs:comment "values containing a time, conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Timestamp
 <http://www.admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Timestamp> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Timestamp"^^xsd:string ;
+    rdfs:label "Timestamp"^^xs:string ;
     rdfs:comment "values containing a time, conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Direction
 aas:Direction rdf:type owl:Class ;
-    rdfs:label "Direction"^^xsd:string ;
+    rdfs:label "Direction"^^xs:string ;
     rdfs:comment "Direction"@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/Direction/Input>
@@ -952,25 +952,25 @@ aas:Direction rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Direction/Input
 <http://www.admin-shell.io/aas/3/0/RC02/Direction/Input> rdf:type aas:Direction ;
-    rdfs:label "Input"^^xsd:string ;
+    rdfs:label "Input"^^xs:string ;
     rdfs:comment "Input direction."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Direction/Output
 <http://www.admin-shell.io/aas/3/0/RC02/Direction/Output> rdf:type aas:Direction ;
-    rdfs:label "Output"^^xsd:string ;
+    rdfs:label "Output"^^xs:string ;
     rdfs:comment "Output direction"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification
 aas:EmbeddedDataSpecification rdf:type owl:Class ;
-    rdfs:label "Embedded Data Specification"^^xsd:string ;
+    rdfs:label "Embedded Data Specification"^^xs:string ;
     rdfs:comment "Embed the content of a data specification."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecification
 <http://www.admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecification> rdf:type owl:ObjectProperty ;
-    rdfs:label "has data specification"^^xsd:string ;
+    rdfs:label "has data specification"^^xs:string ;
     rdfs:domain aas:EmbeddedDataSpecification ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the data specification"@en ;
@@ -978,7 +978,7 @@ aas:EmbeddedDataSpecification rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecificationContent
 <http://www.admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecificationContent> rdf:type owl:ObjectProperty ;
-    rdfs:label "has data specification content"^^xsd:string ;
+    rdfs:label "has data specification content"^^xs:string ;
     rdfs:domain aas:EmbeddedDataSpecification ;
     rdfs:range aas:DataSpecificationContent ;
     rdfs:comment "Actual content of the data specification"@en ;
@@ -987,13 +987,13 @@ aas:EmbeddedDataSpecification rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/Entity
 aas:Entity rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Entity"^^xsd:string ;
+    rdfs:label "Entity"^^xs:string ;
     rdfs:comment "An entity is a submodel element that is used to model entities."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Entity/entityType
 <http://www.admin-shell.io/aas/3/0/RC02/Entity/entityType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has entity type"^^xsd:string ;
+    rdfs:label "has entity type"^^xs:string ;
     rdfs:domain aas:Entity ;
     rdfs:range aas:EntityType ;
     rdfs:comment "Describes whether the entity is a co-managed entity or a self-managed entity."@en ;
@@ -1001,7 +1001,7 @@ aas:Entity rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Entity/globalAssetId
 <http://www.admin-shell.io/aas/3/0/RC02/Entity/globalAssetId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has global asset id"^^xsd:string ;
+    rdfs:label "has global asset id"^^xs:string ;
     rdfs:domain aas:Entity ;
     rdfs:range aas:Reference ;
     rdfs:comment "Global identifier of the asset the entity is representing."@en ;
@@ -1009,7 +1009,7 @@ aas:Entity rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Entity/specificAssetId
 <http://www.admin-shell.io/aas/3/0/RC02/Entity/specificAssetId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has specific asset id"^^xsd:string ;
+    rdfs:label "has specific asset id"^^xs:string ;
     rdfs:domain aas:Entity ;
     rdfs:range aas:SpecificAssetId ;
     rdfs:comment "Reference to a specific asset ID representing a supplementary identifier of the asset represented by the Asset Administration Shell."@en ;
@@ -1017,7 +1017,7 @@ aas:Entity rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Entity/statements
 <http://www.admin-shell.io/aas/3/0/RC02/Entity/statements> rdf:type owl:ObjectProperty ;
-    rdfs:label "has statements"^^xsd:string ;
+    rdfs:label "has statements"^^xs:string ;
     rdfs:domain aas:Entity ;
     rdfs:range aas:SubmodelElement ;
     rdfs:comment "Describes statements applicable to the entity by a set of submodel elements, typically with a qualified value."@en ;
@@ -1025,7 +1025,7 @@ aas:Entity rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EntityType
 aas:EntityType rdf:type owl:Class ;
-    rdfs:label "Entity Type"^^xsd:string ;
+    rdfs:label "Entity Type"^^xs:string ;
     rdfs:comment "Enumeration for denoting whether an entity is a self-managed entity or a co-managed entity."@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/EntityType/CoManagedEntity>
@@ -1035,25 +1035,25 @@ aas:EntityType rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EntityType/CoManagedEntity
 <http://www.admin-shell.io/aas/3/0/RC02/EntityType/CoManagedEntity> rdf:type aas:EntityType ;
-    rdfs:label "Co Managed Entity"^^xsd:string ;
+    rdfs:label "Co Managed Entity"^^xs:string ;
     rdfs:comment "For co-managed entities there is no separate AAS. Co-managed entities need to be part of a self-managed entity."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EntityType/SelfManagedEntity
 <http://www.admin-shell.io/aas/3/0/RC02/EntityType/SelfManagedEntity> rdf:type aas:EntityType ;
-    rdfs:label "Self Managed Entity"^^xsd:string ;
+    rdfs:label "Self Managed Entity"^^xs:string ;
     rdfs:comment "Self-Managed Entities have their own AAS but can be part of the bill of material of a composite self-managed entity."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Environment
 aas:Environment rdf:type owl:Class ;
-    rdfs:label "Environment"^^xsd:string ;
+    rdfs:label "Environment"^^xs:string ;
     rdfs:comment "Container for the sets of different identifiables."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Environment/assetAdministrationShells
 <http://www.admin-shell.io/aas/3/0/RC02/Environment/assetAdministrationShells> rdf:type owl:ObjectProperty ;
-    rdfs:label "has asset administration shells"^^xsd:string ;
+    rdfs:label "has asset administration shells"^^xs:string ;
     rdfs:domain aas:Environment ;
     rdfs:range aas:AssetAdministrationShell ;
     rdfs:comment "Asset administration shell"@en ;
@@ -1061,7 +1061,7 @@ aas:Environment rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Environment/conceptDescriptions
 <http://www.admin-shell.io/aas/3/0/RC02/Environment/conceptDescriptions> rdf:type owl:ObjectProperty ;
-    rdfs:label "has concept descriptions"^^xsd:string ;
+    rdfs:label "has concept descriptions"^^xs:string ;
     rdfs:domain aas:Environment ;
     rdfs:range aas:ConceptDescription ;
     rdfs:comment "Concept description"@en ;
@@ -1069,7 +1069,7 @@ aas:Environment rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Environment/submodels
 <http://www.admin-shell.io/aas/3/0/RC02/Environment/submodels> rdf:type owl:ObjectProperty ;
-    rdfs:label "has submodels"^^xsd:string ;
+    rdfs:label "has submodels"^^xs:string ;
     rdfs:domain aas:Environment ;
     rdfs:range aas:Submodel ;
     rdfs:comment "Submodel"@en ;
@@ -1078,19 +1078,19 @@ aas:Environment rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventElement
 aas:EventElement rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Event Element"^^xsd:string ;
+    rdfs:label "Event Element"^^xs:string ;
     rdfs:comment "An event element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload
 aas:EventPayload rdf:type owl:Class ;
-    rdfs:label "Event Payload"^^xsd:string ;
+    rdfs:label "Event Payload"^^xs:string ;
     rdfs:comment "Defines the necessary information of an event instance sent out or received."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/observableReference
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/observableReference> rdf:type owl:ObjectProperty ;
-    rdfs:label "has observable reference"^^xsd:string ;
+    rdfs:label "has observable reference"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the referable, which defines the scope of the event."@en ;
@@ -1098,7 +1098,7 @@ aas:EventPayload rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/observableSemanticId
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/observableSemanticId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has observable semantic id"^^xsd:string ;
+    rdfs:label "has observable semantic id"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
     rdfs:comment "'semanticId' of the referable which defines the scope of the event, if available."@en ;
@@ -1106,15 +1106,15 @@ aas:EventPayload rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/payload
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/payload> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has payload"^^xsd:string ;
+    rdfs:label "has payload"^^xs:string ;
     rdfs:domain aas:EventPayload ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Event specific payload."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/source
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/source> rdf:type owl:ObjectProperty ;
-    rdfs:label "has source"^^xsd:string ;
+    rdfs:label "has source"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the source event element, including identification of 'AssetAdministrationShell', 'Submodel', 'SubmodelElement''s."@en ;
@@ -1122,7 +1122,7 @@ aas:EventPayload rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/sourceSemanticId
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/sourceSemanticId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has source semantic id"^^xsd:string ;
+    rdfs:label "has source semantic id"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
     rdfs:comment "'semanticId' of the source event element, if available"@en ;
@@ -1130,7 +1130,7 @@ aas:EventPayload rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/subjectId
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/subjectId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has subject id"^^xsd:string ;
+    rdfs:label "has subject id"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
     rdfs:comment "Subject, who/which initiated the creation."@en ;
@@ -1138,38 +1138,38 @@ aas:EventPayload rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/timeStamp
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/timeStamp> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has time stamp"^^xsd:string ;
+    rdfs:label "has time stamp"^^xs:string ;
     rdfs:domain aas:EventPayload ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Timestamp in UTC, when this event was triggered."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/EventPayload/topic
 <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/topic> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has topic"^^xsd:string ;
+    rdfs:label "has topic"^^xs:string ;
     rdfs:domain aas:EventPayload ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Information for the outer message infrastructure for scheduling the event to the respective communication channel."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Extension
 aas:Extension rdf:type owl:Class ;
     rdfs:subClassOf aas:HasSemantics ;
-    rdfs:label "Extension"^^xsd:string ;
+    rdfs:label "Extension"^^xs:string ;
     rdfs:comment "Single extension of an element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Extension/name
 <http://www.admin-shell.io/aas/3/0/RC02/Extension/name> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has name"^^xsd:string ;
+    rdfs:label "has name"^^xs:string ;
     rdfs:domain aas:Extension ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Name of the extension."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Extension/refersTo
 <http://www.admin-shell.io/aas/3/0/RC02/Extension/refersTo> rdf:type owl:ObjectProperty ;
-    rdfs:label "has refers to"^^xsd:string ;
+    rdfs:label "has refers to"^^xs:string ;
     rdfs:domain aas:Extension ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to an element the extension refers to."@en ;
@@ -1177,15 +1177,15 @@ aas:Extension rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Extension/value
 <http://www.admin-shell.io/aas/3/0/RC02/Extension/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Extension ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Value of the extension"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Extension/valueType
 <http://www.admin-shell.io/aas/3/0/RC02/Extension/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
+    rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Extension ;
     rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Type of the value of the extension."@en ;
@@ -1194,35 +1194,35 @@ aas:Extension rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/File
 aas:File rdf:type owl:Class ;
     rdfs:subClassOf aas:DataElement ;
-    rdfs:label "File"^^xsd:string ;
+    rdfs:label "File"^^xs:string ;
     rdfs:comment "A File is a data element that represents an address to a file (a locator)."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/File/contentType
 <http://www.admin-shell.io/aas/3/0/RC02/File/contentType> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has content type"^^xsd:string ;
+    rdfs:label "has content type"^^xs:string ;
     rdfs:domain aas:File ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Content type of the content of the file."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/File/value
 <http://www.admin-shell.io/aas/3/0/RC02/File/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:File ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Path and name of the referenced file (with file extension)."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasDataSpecification
 aas:HasDataSpecification rdf:type owl:Class ;
-    rdfs:label "Has Data Specification"^^xsd:string ;
+    rdfs:label "Has Data Specification"^^xs:string ;
     rdfs:comment "Element that can be extended by using data specification templates."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasDataSpecification/embeddedDataSpecifications
 <http://www.admin-shell.io/aas/3/0/RC02/HasDataSpecification/embeddedDataSpecifications> rdf:type owl:ObjectProperty ;
-    rdfs:label "has embedded data specifications"^^xsd:string ;
+    rdfs:label "has embedded data specifications"^^xs:string ;
     rdfs:domain aas:HasDataSpecification ;
     rdfs:range aas:EmbeddedDataSpecification ;
     rdfs:comment "Embedded data specification."@en ;
@@ -1230,13 +1230,13 @@ aas:HasDataSpecification rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasExtensions
 aas:HasExtensions rdf:type owl:Class ;
-    rdfs:label "Has Extensions"^^xsd:string ;
+    rdfs:label "Has Extensions"^^xs:string ;
     rdfs:comment "Element that can be extended by proprietary extensions."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasExtensions/extensions
 <http://www.admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> rdf:type owl:ObjectProperty ;
-    rdfs:label "has extensions"^^xsd:string ;
+    rdfs:label "has extensions"^^xs:string ;
     rdfs:domain aas:HasExtensions ;
     rdfs:range aas:Extension ;
     rdfs:comment "An extension of the element."@en ;
@@ -1244,13 +1244,13 @@ aas:HasExtensions rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasKind
 aas:HasKind rdf:type owl:Class ;
-    rdfs:label "Has Kind"^^xsd:string ;
+    rdfs:label "Has Kind"^^xs:string ;
     rdfs:comment "An element with a kind is an element that can either represent a template or an instance."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasKind/kind
 <http://www.admin-shell.io/aas/3/0/RC02/HasKind/kind> rdf:type owl:ObjectProperty ;
-    rdfs:label "has kind"^^xsd:string ;
+    rdfs:label "has kind"^^xs:string ;
     rdfs:domain aas:HasKind ;
     rdfs:range aas:ModelingKind ;
     rdfs:comment "Kind of the element: either type or instance."@en ;
@@ -1258,13 +1258,13 @@ aas:HasKind rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasSemantics
 aas:HasSemantics rdf:type owl:Class ;
-    rdfs:label "Has Semantics"^^xsd:string ;
+    rdfs:label "Has Semantics"^^xs:string ;
     rdfs:comment "Element that can have a semantic definition plus some supplemental semantic definitions."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasSemantics/semanticId
 <http://www.admin-shell.io/aas/3/0/RC02/HasSemantics/semanticId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has semantic id"^^xsd:string ;
+    rdfs:label "has semantic id"^^xs:string ;
     rdfs:domain aas:HasSemantics ;
     rdfs:range aas:Reference ;
     rdfs:comment "Identifier of the semantic definition of the element. It is called semantic ID of the element or also main semantic ID of the element."@en ;
@@ -1272,7 +1272,7 @@ aas:HasSemantics rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/HasSemantics/supplementalSemanticIds
 <http://www.admin-shell.io/aas/3/0/RC02/HasSemantics/supplementalSemanticIds> rdf:type owl:ObjectProperty ;
-    rdfs:label "has supplemental semantic ids"^^xsd:string ;
+    rdfs:label "has supplemental semantic ids"^^xs:string ;
     rdfs:domain aas:HasSemantics ;
     rdfs:range aas:Reference ;
     rdfs:comment "Identifier of a supplemental semantic definition of the element. It is called supplemental semantic ID of the element."@en ;
@@ -1281,13 +1281,13 @@ aas:HasSemantics rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/Identifiable
 aas:Identifiable rdf:type owl:Class ;
     rdfs:subClassOf aas:Referable ;
-    rdfs:label "Identifiable"^^xsd:string ;
+    rdfs:label "Identifiable"^^xs:string ;
     rdfs:comment "An element that has a globally unique identifier."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Identifiable/administration
 <http://www.admin-shell.io/aas/3/0/RC02/Identifiable/administration> rdf:type owl:ObjectProperty ;
-    rdfs:label "has administration"^^xsd:string ;
+    rdfs:label "has administration"^^xs:string ;
     rdfs:domain aas:Identifiable ;
     rdfs:range aas:AdministrativeInformation ;
     rdfs:comment "Administrative information of an identifiable element."@en ;
@@ -1295,21 +1295,21 @@ aas:Identifiable rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Identifiable/id
 <http://www.admin-shell.io/aas/3/0/RC02/Identifiable/id> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has id"^^xsd:string ;
+    rdfs:label "has id"^^xs:string ;
     rdfs:domain aas:Identifiable ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The globally unique identification of the element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Key
 aas:Key rdf:type owl:Class ;
-    rdfs:label "Key"^^xsd:string ;
+    rdfs:label "Key"^^xs:string ;
     rdfs:comment "A key is a reference to an element by its ID."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Key/type
 <http://www.admin-shell.io/aas/3/0/RC02/Key/type> rdf:type owl:ObjectProperty ;
-    rdfs:label "has type"^^xsd:string ;
+    rdfs:label "has type"^^xs:string ;
     rdfs:domain aas:Key ;
     rdfs:range aas:KeyTypes ;
     rdfs:comment "Denotes which kind of entity is referenced."@en ;
@@ -1317,15 +1317,15 @@ aas:Key rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Key/value
 <http://www.admin-shell.io/aas/3/0/RC02/Key/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Key ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The key value, for example an IRDI or an URI"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes
 aas:KeyTypes rdf:type owl:Class ;
-    rdfs:label "Key Types"^^xsd:string ;
+    rdfs:label "Key Types"^^xs:string ;
     rdfs:comment "Enumeration of different key value types within a key."@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/AnnotatedRelationshipElement>
@@ -1357,160 +1357,160 @@ aas:KeyTypes rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/AnnotatedRelationshipElement
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/AnnotatedRelationshipElement> rdf:type aas:KeyTypes ;
-    rdfs:label "Annotated Relationship Element"^^xsd:string ;
+    rdfs:label "Annotated Relationship Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/AssetAdministrationShell
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/AssetAdministrationShell> rdf:type aas:KeyTypes ;
-    rdfs:label "Asset Administration Shell"^^xsd:string ;
+    rdfs:label "Asset Administration Shell"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/BasicEventElement
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/BasicEventElement> rdf:type aas:KeyTypes ;
-    rdfs:label "Basic Event Element"^^xsd:string ;
+    rdfs:label "Basic Event Element"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Blob
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Blob> rdf:type aas:KeyTypes ;
-    rdfs:label "Blob"^^xsd:string ;
+    rdfs:label "Blob"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Capability
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Capability> rdf:type aas:KeyTypes ;
-    rdfs:label "Capability"^^xsd:string ;
+    rdfs:label "Capability"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/ConceptDescription
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/ConceptDescription> rdf:type aas:KeyTypes ;
-    rdfs:label "Concept Description"^^xsd:string ;
+    rdfs:label "Concept Description"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/DataElement
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/DataElement> rdf:type aas:KeyTypes ;
-    rdfs:label "Data Element"^^xsd:string ;
+    rdfs:label "Data Element"^^xs:string ;
     rdfs:comment "Data element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Entity
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Entity> rdf:type aas:KeyTypes ;
-    rdfs:label "Entity"^^xsd:string ;
+    rdfs:label "Entity"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/EventElement
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/EventElement> rdf:type aas:KeyTypes ;
-    rdfs:label "Event Element"^^xsd:string ;
+    rdfs:label "Event Element"^^xs:string ;
     rdfs:comment "Event."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/File
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/File> rdf:type aas:KeyTypes ;
-    rdfs:label "File"^^xsd:string ;
+    rdfs:label "File"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/FragmentReference
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/FragmentReference> rdf:type aas:KeyTypes ;
-    rdfs:label "Fragment Reference"^^xsd:string ;
+    rdfs:label "Fragment Reference"^^xs:string ;
     rdfs:comment "Bookmark or a similar local identifier of a subordinate part of a primary resource"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/GlobalReference
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/GlobalReference> rdf:type aas:KeyTypes ;
-    rdfs:label "Global Reference"^^xsd:string ;
+    rdfs:label "Global Reference"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Identifiable
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Identifiable> rdf:type aas:KeyTypes ;
-    rdfs:label "Identifiable"^^xsd:string ;
+    rdfs:label "Identifiable"^^xs:string ;
     rdfs:comment "Identifiable."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/MultiLanguageProperty
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/MultiLanguageProperty> rdf:type aas:KeyTypes ;
-    rdfs:label "Multi Language Property"^^xsd:string ;
+    rdfs:label "Multi Language Property"^^xs:string ;
     rdfs:comment "Property with a value that can be provided in multiple languages"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Operation
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Operation> rdf:type aas:KeyTypes ;
-    rdfs:label "Operation"^^xsd:string ;
+    rdfs:label "Operation"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Property
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Property> rdf:type aas:KeyTypes ;
-    rdfs:label "Property"^^xsd:string ;
+    rdfs:label "Property"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Range
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Range> rdf:type aas:KeyTypes ;
-    rdfs:label "Range"^^xsd:string ;
+    rdfs:label "Range"^^xs:string ;
     rdfs:comment "Range with min and max"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Referable
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Referable> rdf:type aas:KeyTypes ;
-    rdfs:label "Referable"^^xsd:string ;
+    rdfs:label "Referable"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/ReferenceElement
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/ReferenceElement> rdf:type aas:KeyTypes ;
-    rdfs:label "Reference Element"^^xsd:string ;
+    rdfs:label "Reference Element"^^xs:string ;
     rdfs:comment "Reference"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/RelationshipElement
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/RelationshipElement> rdf:type aas:KeyTypes ;
-    rdfs:label "Relationship Element"^^xsd:string ;
+    rdfs:label "Relationship Element"^^xs:string ;
     rdfs:comment "Relationship"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Submodel
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/Submodel> rdf:type aas:KeyTypes ;
-    rdfs:label "Submodel"^^xsd:string ;
+    rdfs:label "Submodel"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/SubmodelElement
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/SubmodelElement> rdf:type aas:KeyTypes ;
-    rdfs:label "Submodel Element"^^xsd:string ;
+    rdfs:label "Submodel Element"^^xs:string ;
     rdfs:comment "Submodel Element"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/SubmodelElementCollection
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/SubmodelElementCollection> rdf:type aas:KeyTypes ;
-    rdfs:label "Submodel Element Collection"^^xsd:string ;
+    rdfs:label "Submodel Element Collection"^^xs:string ;
     rdfs:comment "Struct of Submodel Elements"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/SubmodelElementList
 <http://www.admin-shell.io/aas/3/0/RC02/KeyTypes/SubmodelElementList> rdf:type aas:KeyTypes ;
-    rdfs:label "Submodel Element List"^^xsd:string ;
+    rdfs:label "Submodel Element List"^^xs:string ;
     rdfs:comment "List of Submodel Elements"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LangString
 aas:LangString rdf:type owl:Class ;
-    rdfs:label "Lang String"^^xsd:string ;
+    rdfs:label "Lang String"^^xs:string ;
     rdfs:comment "Strings with language tags"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LangString/language
 <http://www.admin-shell.io/aas/3/0/RC02/LangString/language> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has language"^^xsd:string ;
+    rdfs:label "has language"^^xs:string ;
     rdfs:domain aas:LangString ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Language tag conforming to BCP 47"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LangString/text
 <http://www.admin-shell.io/aas/3/0/RC02/LangString/text> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has text"^^xsd:string ;
+    rdfs:label "has text"^^xs:string ;
     rdfs:domain aas:LangString ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Text in the 'language'"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LevelType
 aas:LevelType rdf:type owl:Class ;
-    rdfs:label "Level Type"^^xsd:string ;
+    rdfs:label "Level Type"^^xs:string ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/LevelType/Max>
         <http://www.admin-shell.io/aas/3/0/RC02/LevelType/Min>
@@ -1521,27 +1521,27 @@ aas:LevelType rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LevelType/Max
 <http://www.admin-shell.io/aas/3/0/RC02/LevelType/Max> rdf:type aas:LevelType ;
-    rdfs:label "Max"^^xsd:string ;
+    rdfs:label "Max"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LevelType/Min
 <http://www.admin-shell.io/aas/3/0/RC02/LevelType/Min> rdf:type aas:LevelType ;
-    rdfs:label "Min"^^xsd:string ;
+    rdfs:label "Min"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LevelType/Nom
 <http://www.admin-shell.io/aas/3/0/RC02/LevelType/Nom> rdf:type aas:LevelType ;
-    rdfs:label "Nom"^^xsd:string ;
+    rdfs:label "Nom"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/LevelType/Typ
 <http://www.admin-shell.io/aas/3/0/RC02/LevelType/Typ> rdf:type aas:LevelType ;
-    rdfs:label "Typ"^^xsd:string ;
+    rdfs:label "Typ"^^xs:string ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ModelingKind
 aas:ModelingKind rdf:type owl:Class ;
-    rdfs:label "Modeling Kind"^^xsd:string ;
+    rdfs:label "Modeling Kind"^^xs:string ;
     rdfs:comment "Enumeration for denoting whether an element is a template or an instance."@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/ModelingKind/Instance>
@@ -1551,26 +1551,26 @@ aas:ModelingKind rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ModelingKind/Instance
 <http://www.admin-shell.io/aas/3/0/RC02/ModelingKind/Instance> rdf:type aas:ModelingKind ;
-    rdfs:label "Instance"^^xsd:string ;
+    rdfs:label "Instance"^^xs:string ;
     rdfs:comment "Concrete, clearly identifiable component of a certain template."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ModelingKind/Template
 <http://www.admin-shell.io/aas/3/0/RC02/ModelingKind/Template> rdf:type aas:ModelingKind ;
-    rdfs:label "Template"^^xsd:string ;
+    rdfs:label "Template"^^xs:string ;
     rdfs:comment "Software element which specifies the common attributes shared by all instances of the template."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/MultiLanguageProperty
 aas:MultiLanguageProperty rdf:type owl:Class ;
     rdfs:subClassOf aas:DataElement ;
-    rdfs:label "Multi Language Property"^^xsd:string ;
+    rdfs:label "Multi Language Property"^^xs:string ;
     rdfs:comment "A property is a data element that has a multi-language value."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/value
 <http://www.admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/value> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:MultiLanguageProperty ;
     rdfs:range aas:LangString ;
     rdfs:comment "The value of the property instance."@en ;
@@ -1578,7 +1578,7 @@ aas:MultiLanguageProperty rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/valueId
 <http://www.admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/valueId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value id"^^xsd:string ;
+    rdfs:label "has value id"^^xs:string ;
     rdfs:domain aas:MultiLanguageProperty ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the global unique ID of a coded value."@en ;
@@ -1587,13 +1587,13 @@ aas:MultiLanguageProperty rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/Operation
 aas:Operation rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Operation"^^xsd:string ;
+    rdfs:label "Operation"^^xs:string ;
     rdfs:comment "An operation is a submodel element with input and output variables."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Operation/inoutputVariables
 <http://www.admin-shell.io/aas/3/0/RC02/Operation/inoutputVariables> rdf:type owl:ObjectProperty ;
-    rdfs:label "has inoutput variables"^^xsd:string ;
+    rdfs:label "has inoutput variables"^^xs:string ;
     rdfs:domain aas:Operation ;
     rdfs:range aas:OperationVariable ;
     rdfs:comment "Parameter that is input and output of the operation."@en ;
@@ -1601,7 +1601,7 @@ aas:Operation rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Operation/inputVariables
 <http://www.admin-shell.io/aas/3/0/RC02/Operation/inputVariables> rdf:type owl:ObjectProperty ;
-    rdfs:label "has input variables"^^xsd:string ;
+    rdfs:label "has input variables"^^xs:string ;
     rdfs:domain aas:Operation ;
     rdfs:range aas:OperationVariable ;
     rdfs:comment "Input parameter of the operation."@en ;
@@ -1609,7 +1609,7 @@ aas:Operation rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Operation/outputVariables
 <http://www.admin-shell.io/aas/3/0/RC02/Operation/outputVariables> rdf:type owl:ObjectProperty ;
-    rdfs:label "has output variables"^^xsd:string ;
+    rdfs:label "has output variables"^^xs:string ;
     rdfs:domain aas:Operation ;
     rdfs:range aas:OperationVariable ;
     rdfs:comment "Output parameter of the operation."@en ;
@@ -1617,13 +1617,13 @@ aas:Operation rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/OperationVariable
 aas:OperationVariable rdf:type owl:Class ;
-    rdfs:label "Operation Variable"^^xsd:string ;
+    rdfs:label "Operation Variable"^^xs:string ;
     rdfs:comment "The value of an operation variable is a submodel element that is used as input and/or output variable of an operation."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/OperationVariable/value
 <http://www.admin-shell.io/aas/3/0/RC02/OperationVariable/value> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:OperationVariable ;
     rdfs:range aas:SubmodelElement ;
     rdfs:comment "Describes an argument or result of an operation via a submodel element"@en ;
@@ -1632,21 +1632,21 @@ aas:OperationVariable rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/Property
 aas:Property rdf:type owl:Class ;
     rdfs:subClassOf aas:DataElement ;
-    rdfs:label "Property"^^xsd:string ;
+    rdfs:label "Property"^^xs:string ;
     rdfs:comment "A property is a data element that has a single value."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Property/value
 <http://www.admin-shell.io/aas/3/0/RC02/Property/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Property ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The value of the property instance."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Property/valueId
 <http://www.admin-shell.io/aas/3/0/RC02/Property/valueId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value id"^^xsd:string ;
+    rdfs:label "has value id"^^xs:string ;
     rdfs:domain aas:Property ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the global unique ID of a coded value."@en ;
@@ -1654,7 +1654,7 @@ aas:Property rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Property/valueType
 <http://www.admin-shell.io/aas/3/0/RC02/Property/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
+    rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Property ;
     rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Data type of the value"@en ;
@@ -1662,13 +1662,13 @@ aas:Property rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifiable
 aas:Qualifiable rdf:type owl:Class ;
-    rdfs:label "Qualifiable"^^xsd:string ;
+    rdfs:label "Qualifiable"^^xs:string ;
     rdfs:comment "The value of a qualifiable element may be further qualified by one or more qualifiers."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers
 <http://www.admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> rdf:type owl:ObjectProperty ;
-    rdfs:label "has qualifiers"^^xsd:string ;
+    rdfs:label "has qualifiers"^^xs:string ;
     rdfs:domain aas:Qualifiable ;
     rdfs:range aas:Qualifier ;
     rdfs:comment "Additional qualification of a qualifiable element."@en ;
@@ -1677,13 +1677,13 @@ aas:Qualifiable rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifier
 aas:Qualifier rdf:type owl:Class ;
     rdfs:subClassOf aas:HasSemantics ;
-    rdfs:label "Qualifier"^^xsd:string ;
+    rdfs:label "Qualifier"^^xs:string ;
     rdfs:comment "A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifier/kind
 <http://www.admin-shell.io/aas/3/0/RC02/Qualifier/kind> rdf:type owl:ObjectProperty ;
-    rdfs:label "has kind"^^xsd:string ;
+    rdfs:label "has kind"^^xs:string ;
     rdfs:domain aas:Qualifier ;
     rdfs:range aas:QualifierKind ;
     rdfs:comment "The qualifier kind describes the kind of the qualifier that is applied to the element."@en ;
@@ -1691,23 +1691,23 @@ aas:Qualifier rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifier/type
 <http://www.admin-shell.io/aas/3/0/RC02/Qualifier/type> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has type"^^xsd:string ;
+    rdfs:label "has type"^^xs:string ;
     rdfs:domain aas:Qualifier ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The qualifier type describes the type of the qualifier that is applied to the element."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifier/value
 <http://www.admin-shell.io/aas/3/0/RC02/Qualifier/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Qualifier ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The qualifier value is the value of the qualifier."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifier/valueId
 <http://www.admin-shell.io/aas/3/0/RC02/Qualifier/valueId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value id"^^xsd:string ;
+    rdfs:label "has value id"^^xs:string ;
     rdfs:domain aas:Qualifier ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the global unique ID of a coded value."@en ;
@@ -1715,7 +1715,7 @@ aas:Qualifier rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Qualifier/valueType
 <http://www.admin-shell.io/aas/3/0/RC02/Qualifier/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
+    rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Qualifier ;
     rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Data type of the qualifier value."@en ;
@@ -1723,7 +1723,7 @@ aas:Qualifier rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/QualifierKind
 aas:QualifierKind rdf:type owl:Class ;
-    rdfs:label "Qualifier Kind"^^xsd:string ;
+    rdfs:label "Qualifier Kind"^^xs:string ;
     rdfs:comment "Enumeration for kinds of qualifiers."@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/QualifierKind/ConceptQualifier>
@@ -1734,48 +1734,48 @@ aas:QualifierKind rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/QualifierKind/ConceptQualifier
 <http://www.admin-shell.io/aas/3/0/RC02/QualifierKind/ConceptQualifier> rdf:type aas:QualifierKind ;
-    rdfs:label "Concept Qualifier"^^xsd:string ;
+    rdfs:label "Concept Qualifier"^^xs:string ;
     rdfs:comment "qualifies the semantic definition the element is referring to ('semanticId')"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/QualifierKind/TemplateQualifier
 <http://www.admin-shell.io/aas/3/0/RC02/QualifierKind/TemplateQualifier> rdf:type aas:QualifierKind ;
-    rdfs:label "Template Qualifier"^^xsd:string ;
+    rdfs:label "Template Qualifier"^^xs:string ;
     rdfs:comment "qualifies the elements within a specific submodel on concept level."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/QualifierKind/ValueQualifier
 <http://www.admin-shell.io/aas/3/0/RC02/QualifierKind/ValueQualifier> rdf:type aas:QualifierKind ;
-    rdfs:label "Value Qualifier"^^xsd:string ;
+    rdfs:label "Value Qualifier"^^xs:string ;
     rdfs:comment "qualifies the value of the element and can change during run-time."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Range
 aas:Range rdf:type owl:Class ;
     rdfs:subClassOf aas:DataElement ;
-    rdfs:label "Range"^^xsd:string ;
+    rdfs:label "Range"^^xs:string ;
     rdfs:comment "A range data element is a data element that defines a range with min and max."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Range/max
 <http://www.admin-shell.io/aas/3/0/RC02/Range/max> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has max"^^xsd:string ;
+    rdfs:label "has max"^^xs:string ;
     rdfs:domain aas:Range ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The maximum value of the range."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Range/min
 <http://www.admin-shell.io/aas/3/0/RC02/Range/min> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has min"^^xsd:string ;
+    rdfs:label "has min"^^xs:string ;
     rdfs:domain aas:Range ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The minimum value of the range."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Range/valueType
 <http://www.admin-shell.io/aas/3/0/RC02/Range/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
+    rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Range ;
     rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Data type of the min und max"@en ;
@@ -1784,29 +1784,29 @@ aas:Range rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/Referable
 aas:Referable rdf:type owl:Class ;
     rdfs:subClassOf aas:HasExtensions ;
-    rdfs:label "Referable"^^xsd:string ;
+    rdfs:label "Referable"^^xs:string ;
     rdfs:comment "An element that is referable by its 'idShort'."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Referable/category
 <http://www.admin-shell.io/aas/3/0/RC02/Referable/category> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has category"^^xsd:string ;
+    rdfs:label "has category"^^xs:string ;
     rdfs:domain aas:Referable ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Referable/checksum
 <http://www.admin-shell.io/aas/3/0/RC02/Referable/checksum> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has checksum"^^xsd:string ;
+    rdfs:label "has checksum"^^xs:string ;
     rdfs:domain aas:Referable ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Checksum to be used to determine if an Referable (including its aggregated child elements) has changed."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Referable/description
 <http://www.admin-shell.io/aas/3/0/RC02/Referable/description> rdf:type owl:ObjectProperty ;
-    rdfs:label "has description"^^xsd:string ;
+    rdfs:label "has description"^^xs:string ;
     rdfs:domain aas:Referable ;
     rdfs:range aas:LangString ;
     rdfs:comment "Description or comments on the element."@en ;
@@ -1814,7 +1814,7 @@ aas:Referable rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Referable/displayName
 <http://www.admin-shell.io/aas/3/0/RC02/Referable/displayName> rdf:type owl:ObjectProperty ;
-    rdfs:label "has display name"^^xsd:string ;
+    rdfs:label "has display name"^^xs:string ;
     rdfs:domain aas:Referable ;
     rdfs:range aas:LangString ;
     rdfs:comment "Display name. Can be provided in several languages."@en ;
@@ -1822,21 +1822,21 @@ aas:Referable rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Referable/idShort
 <http://www.admin-shell.io/aas/3/0/RC02/Referable/idShort> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has id short"^^xsd:string ;
+    rdfs:label "has id short"^^xs:string ;
     rdfs:domain aas:Referable ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "In case of identifiables this attribute is a short name of the element. In case of referable this ID is an identifying string of the element within its name space."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Reference
 aas:Reference rdf:type owl:Class ;
-    rdfs:label "Reference"^^xsd:string ;
+    rdfs:label "Reference"^^xs:string ;
     rdfs:comment "Reference to either a model element of the same or another AAS or to an external entity."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Reference/keys
 <http://www.admin-shell.io/aas/3/0/RC02/Reference/keys> rdf:type owl:ObjectProperty ;
-    rdfs:label "has keys"^^xsd:string ;
+    rdfs:label "has keys"^^xs:string ;
     rdfs:domain aas:Reference ;
     rdfs:range aas:Key ;
     rdfs:comment "Unique references in their name space."@en ;
@@ -1844,7 +1844,7 @@ aas:Reference rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Reference/referredSemanticId
 <http://www.admin-shell.io/aas/3/0/RC02/Reference/referredSemanticId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has referred semantic id"^^xsd:string ;
+    rdfs:label "has referred semantic id"^^xs:string ;
     rdfs:domain aas:Reference ;
     rdfs:range aas:Reference ;
     rdfs:comment "'semanticId' of the referenced model element ('type' = 'ModelReference')."@en ;
@@ -1852,7 +1852,7 @@ aas:Reference rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Reference/type
 <http://www.admin-shell.io/aas/3/0/RC02/Reference/type> rdf:type owl:ObjectProperty ;
-    rdfs:label "has type"^^xsd:string ;
+    rdfs:label "has type"^^xs:string ;
     rdfs:domain aas:Reference ;
     rdfs:range aas:ReferenceTypes ;
     rdfs:comment "Type of the reference."@en ;
@@ -1861,13 +1861,13 @@ aas:Reference rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/ReferenceElement
 aas:ReferenceElement rdf:type owl:Class ;
     rdfs:subClassOf aas:DataElement ;
-    rdfs:label "Reference Element"^^xsd:string ;
+    rdfs:label "Reference Element"^^xs:string ;
     rdfs:comment "A reference element is a data element that defines a logical reference to another element within the same or another AAS or a reference to an external object or entity."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ReferenceElement/value
 <http://www.admin-shell.io/aas/3/0/RC02/ReferenceElement/value> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:ReferenceElement ;
     rdfs:range aas:Reference ;
     rdfs:comment "Global reference to an external object or entity or a logical reference to another element within the same or another AAS (i.e. a model reference to a Referable)."@en ;
@@ -1875,7 +1875,7 @@ aas:ReferenceElement rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ReferenceTypes
 aas:ReferenceTypes rdf:type owl:Class ;
-    rdfs:label "Reference Types"^^xsd:string ;
+    rdfs:label "Reference Types"^^xs:string ;
     rdfs:comment "ReferenceTypes"@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/ReferenceTypes/GlobalReference>
@@ -1885,26 +1885,26 @@ aas:ReferenceTypes rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ReferenceTypes/GlobalReference
 <http://www.admin-shell.io/aas/3/0/RC02/ReferenceTypes/GlobalReference> rdf:type aas:ReferenceTypes ;
-    rdfs:label "Global Reference"^^xsd:string ;
+    rdfs:label "Global Reference"^^xs:string ;
     rdfs:comment "GlobalReference."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ReferenceTypes/ModelReference
 <http://www.admin-shell.io/aas/3/0/RC02/ReferenceTypes/ModelReference> rdf:type aas:ReferenceTypes ;
-    rdfs:label "Model Reference"^^xsd:string ;
+    rdfs:label "Model Reference"^^xs:string ;
     rdfs:comment "ModelReference"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/RelationshipElement
 aas:RelationshipElement rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Relationship Element"^^xsd:string ;
+    rdfs:label "Relationship Element"^^xs:string ;
     rdfs:comment "A relationship element is used to define a relationship between two elements being either referable (model reference) or external (global reference)."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/RelationshipElement/first
 <http://www.admin-shell.io/aas/3/0/RC02/RelationshipElement/first> rdf:type owl:ObjectProperty ;
-    rdfs:label "has first"^^xsd:string ;
+    rdfs:label "has first"^^xs:string ;
     rdfs:domain aas:RelationshipElement ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the first element in the relationship taking the role of the subject."@en ;
@@ -1912,7 +1912,7 @@ aas:RelationshipElement rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/RelationshipElement/second
 <http://www.admin-shell.io/aas/3/0/RC02/RelationshipElement/second> rdf:type owl:ObjectProperty ;
-    rdfs:label "has second"^^xsd:string ;
+    rdfs:label "has second"^^xs:string ;
     rdfs:domain aas:RelationshipElement ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the second element in the relationship taking the role of the object."@en ;
@@ -1920,36 +1920,36 @@ aas:RelationshipElement rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Resource
 aas:Resource rdf:type owl:Class ;
-    rdfs:label "Resource"^^xsd:string ;
+    rdfs:label "Resource"^^xs:string ;
     rdfs:comment "Resource represents an address to a file (a locator). The value is an URI that can represent an absolute or relative path"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Resource/contentType
 <http://www.admin-shell.io/aas/3/0/RC02/Resource/contentType> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has content type"^^xsd:string ;
+    rdfs:label "has content type"^^xs:string ;
     rdfs:domain aas:Resource ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Content type of the content of the file."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Resource/path
 <http://www.admin-shell.io/aas/3/0/RC02/Resource/path> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has path"^^xsd:string ;
+    rdfs:label "has path"^^xs:string ;
     rdfs:domain aas:Resource ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Path and name of the resource (with file extension)."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId
 aas:SpecificAssetId rdf:type owl:Class ;
     rdfs:subClassOf aas:HasSemantics ;
-    rdfs:label "Specific Asset Id"^^xsd:string ;
+    rdfs:label "Specific Asset Id"^^xs:string ;
     rdfs:comment "A specific asset ID describes a generic supplementary identifying attribute of the asset."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/externalSubjectId
 <http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/externalSubjectId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has external subject id"^^xsd:string ;
+    rdfs:label "has external subject id"^^xs:string ;
     rdfs:domain aas:SpecificAssetId ;
     rdfs:range aas:Reference ;
     rdfs:comment "The (external) subject the key belongs to or has meaning to."@en ;
@@ -1957,23 +1957,23 @@ aas:SpecificAssetId rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/name
 <http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/name> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has name"^^xsd:string ;
+    rdfs:label "has name"^^xs:string ;
     rdfs:domain aas:SpecificAssetId ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "Name of the identifier"@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/value
 <http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:SpecificAssetId ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The value of the specific asset identifier with the corresponding name."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/StateOfEvent
 aas:StateOfEvent rdf:type owl:Class ;
-    rdfs:label "State Of Event"^^xsd:string ;
+    rdfs:label "State Of Event"^^xs:string ;
     rdfs:comment "State of an event"@en ;
     owl:oneOf (
         <http://www.admin-shell.io/aas/3/0/RC02/StateOfEvent/Off>
@@ -1983,13 +1983,13 @@ aas:StateOfEvent rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/StateOfEvent/Off
 <http://www.admin-shell.io/aas/3/0/RC02/StateOfEvent/Off> rdf:type aas:StateOfEvent ;
-    rdfs:label "Off"^^xsd:string ;
+    rdfs:label "Off"^^xs:string ;
     rdfs:comment "Event is off."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/StateOfEvent/On
 <http://www.admin-shell.io/aas/3/0/RC02/StateOfEvent/On> rdf:type aas:StateOfEvent ;
-    rdfs:label "On"^^xsd:string ;
+    rdfs:label "On"^^xs:string ;
     rdfs:comment "Event is on"@en ;
 .
 
@@ -2000,13 +2000,13 @@ aas:Submodel rdf:type owl:Class ;
     rdfs:subClassOf aas:HasSemantics ;
     rdfs:subClassOf aas:Qualifiable ;
     rdfs:subClassOf aas:HasDataSpecification ;
-    rdfs:label "Submodel"^^xsd:string ;
+    rdfs:label "Submodel"^^xs:string ;
     rdfs:comment "A submodel defines a specific aspect of the asset represented by the AAS."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/Submodel/submodelElements
 <http://www.admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> rdf:type owl:ObjectProperty ;
-    rdfs:label "has submodel elements"^^xsd:string ;
+    rdfs:label "has submodel elements"^^xs:string ;
     rdfs:domain aas:Submodel ;
     rdfs:range aas:SubmodelElement ;
     rdfs:comment "A submodel consists of zero or more submodel elements."@en ;
@@ -2019,20 +2019,20 @@ aas:SubmodelElement rdf:type owl:Class ;
     rdfs:subClassOf aas:HasSemantics ;
     rdfs:subClassOf aas:Qualifiable ;
     rdfs:subClassOf aas:HasDataSpecification ;
-    rdfs:label "Submodel Element"^^xsd:string ;
+    rdfs:label "Submodel Element"^^xs:string ;
     rdfs:comment "A submodel element is an element suitable for the description and differentiation of assets."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementCollection
 aas:SubmodelElementCollection rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Submodel Element Collection"^^xsd:string ;
+    rdfs:label "Submodel Element Collection"^^xs:string ;
     rdfs:comment "A submodel element collection is a kind of struct, i.e. a a logical encapsulation of multiple named values. It has a fixed number of submodel elements."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementCollection/value
 <http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementCollection/value> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:SubmodelElementCollection ;
     rdfs:range aas:SubmodelElement ;
     rdfs:comment "Submodel element contained in the collection."@en ;
@@ -2041,21 +2041,21 @@ aas:SubmodelElementCollection rdf:type owl:Class ;
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList
 aas:SubmodelElementList rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
-    rdfs:label "Submodel Element List"^^xsd:string ;
+    rdfs:label "Submodel Element List"^^xs:string ;
     rdfs:comment "A submodel element list is an ordered list of submodel elements."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/orderRelevant
 <http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/orderRelevant> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has order relevant"^^xsd:string ;
+    rdfs:label "has order relevant"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
-    rdfs:range xsd:boolean ;
+    rdfs:range xs:boolean ;
     rdfs:comment "Defines whether order in list is relevant. If 'orderRelevant' = False then the list is representing a set or a bag."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/semanticIdListElement
 <http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/semanticIdListElement> rdf:type owl:ObjectProperty ;
-    rdfs:label "has semantic id list element"^^xsd:string ;
+    rdfs:label "has semantic id list element"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
     rdfs:range aas:Reference ;
     rdfs:comment "Semantic ID the submodel elements contained in the list match to."@en ;
@@ -2063,7 +2063,7 @@ aas:SubmodelElementList rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/typeValueListElement
 <http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/typeValueListElement> rdf:type owl:ObjectProperty ;
-    rdfs:label "has type value list element"^^xsd:string ;
+    rdfs:label "has type value list element"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
     rdfs:range aas:AasSubmodelElements ;
     rdfs:comment "The submodel element type of the submodel elements contained in the list."@en ;
@@ -2071,7 +2071,7 @@ aas:SubmodelElementList rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/value
 <http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/value> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
     rdfs:range aas:SubmodelElement ;
     rdfs:comment "Submodel element contained in the list."@en ;
@@ -2079,7 +2079,7 @@ aas:SubmodelElementList rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/valueTypeListElement
 <http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/valueTypeListElement> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type list element"^^xsd:string ;
+    rdfs:label "has value type list element"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
     rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "The value type of the submodel element contained in the list."@en ;
@@ -2087,13 +2087,13 @@ aas:SubmodelElementList rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ValueList
 aas:ValueList rdf:type owl:Class ;
-    rdfs:label "Value List"^^xsd:string ;
+    rdfs:label "Value List"^^xs:string ;
     rdfs:comment "A set of value reference pairs."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ValueList/valueReferencePairs
 <http://www.admin-shell.io/aas/3/0/RC02/ValueList/valueReferencePairs> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value reference pairs"^^xsd:string ;
+    rdfs:label "has value reference pairs"^^xs:string ;
     rdfs:domain aas:ValueList ;
     rdfs:range aas:ValueReferencePair ;
     rdfs:comment "A pair of a value together with its global unique id."@en ;
@@ -2101,21 +2101,21 @@ aas:ValueList rdf:type owl:Class ;
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ValueReferencePair
 aas:ValueReferencePair rdf:type owl:Class ;
-    rdfs:label "Value Reference Pair"^^xsd:string ;
+    rdfs:label "Value Reference Pair"^^xs:string ;
     rdfs:comment "A value reference pair within a value list. Each value has a global unique id defining its semantic."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ValueReferencePair/value
 <http://www.admin-shell.io/aas/3/0/RC02/ValueReferencePair/value> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value"^^xsd:string ;
+    rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:ValueReferencePair ;
-    rdfs:range xsd:string ;
+    rdfs:range xs:string ;
     rdfs:comment "The value of the referenced concept definition of the value in valueId."@en ;
 .
 
 ###  http://www.admin-shell.io/aas/3/0/RC02/ValueReferencePair/valueId
 <http://www.admin-shell.io/aas/3/0/RC02/ValueReferencePair/valueId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value id"^^xsd:string ;
+    rdfs:label "has value id"^^xs:string ;
     rdfs:domain aas:ValueReferencePair ;
     rdfs:range aas:Reference ;
     rdfs:comment "Global unique id of the value."@en ;

--- a/schemas/rdf/shacl-schema.ttl
+++ b/schemas/rdf/shacl-schema.ttl
@@ -3,7 +3,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
 
 # Metadata
 <http://www.admin-shell.io/aas/3/0/RC02/> a owl:Ontology ;
@@ -11,8 +11,8 @@
     owl:imports sh: ;
     sh:declare [
         a sh:PrefixDeclaration ;
-        sh:namespace "http://www.admin-shell.io/aas/3/0/RC02/"^^xsd:anyURI ;
-        sh:prefix "aas"^^xsd:string ;
+        sh:namespace "http://www.admin-shell.io/aas/3/0/RC02/"^^xs:anyURI ;
+        sh:prefix "aas"^^xs:string ;
     ] ;
 .
 
@@ -22,7 +22,7 @@ aas:AdministrativeInformationShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/AdministrativeInformation/version> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -30,7 +30,7 @@ aas:AdministrativeInformationShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/AdministrativeInformation/revision> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -132,7 +132,7 @@ aas:BasicEventElementShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/messageTopic> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -147,7 +147,7 @@ aas:BasicEventElementShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/lastUpdate> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
@@ -155,7 +155,7 @@ aas:BasicEventElementShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/minInterval> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
@@ -163,7 +163,7 @@ aas:BasicEventElementShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/BasicEventElement/maxInterval> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
@@ -176,14 +176,14 @@ aas:BlobShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Blob/value> ;
-        sh:datatype xsd:byte ;
+        sh:datatype xs:byte ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Blob/contentType> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -259,7 +259,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unit> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -274,7 +274,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/sourceOfDefinition> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -282,7 +282,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/symbol> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -303,7 +303,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueFormat> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -318,7 +318,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -337,7 +337,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitName> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -345,7 +345,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitSymbol> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -359,7 +359,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -367,7 +367,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -375,7 +375,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -383,7 +383,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -391,7 +391,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -399,7 +399,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -407,7 +407,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/sourceOfDefinition> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -415,7 +415,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/conversionFactor> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -423,7 +423,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/registrationAuthorityId> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -431,7 +431,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/supplier> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -560,7 +560,7 @@ aas:EventPayloadShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/topic> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -575,7 +575,7 @@ aas:EventPayloadShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/timeStamp> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
@@ -583,7 +583,7 @@ aas:EventPayloadShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/EventPayload/payload> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -596,7 +596,7 @@ aas:ExtensionShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Extension/name> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -611,7 +611,7 @@ aas:ExtensionShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Extension/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -630,7 +630,7 @@ aas:FileShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/File/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -639,7 +639,7 @@ aas:FileShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/File/contentType> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -768,7 +768,7 @@ aas:IdentifiableShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Identifiable/id> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -787,7 +787,7 @@ aas:KeyShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Key/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -799,7 +799,7 @@ aas:LangStringShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/LangString/language> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:pattern "^(([a-zA-Z]{2,3}(-[a-zA-Z]{3}(-[a-zA-Z]{3}){2})?|[a-zA-Z]{4}|[a-zA-Z]{5,8})(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-(([a-zA-Z0-9]){5,8}|[0-9]([a-zA-Z0-9]){3}))*(-[0-9A-WY-Za-wy-z](-([a-zA-Z0-9]){2,8})+)*(-[xX](-([a-zA-Z0-9]){1,8})+)?|[xX](-([a-zA-Z0-9]){1,8})+|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$" ;
@@ -807,7 +807,7 @@ aas:LangStringShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/LangString/text> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
@@ -878,7 +878,7 @@ aas:PropertyShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Property/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -926,7 +926,7 @@ aas:QualifierShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Qualifier/type> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -941,7 +941,7 @@ aas:QualifierShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Qualifier/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -967,14 +967,14 @@ aas:RangeShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Range/min> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Range/max> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -998,7 +998,7 @@ aas:ReferableShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Referable/category> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -1006,7 +1006,7 @@ aas:ReferableShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Referable/idShort> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:maxLength 128 ;
@@ -1027,7 +1027,7 @@ aas:ReferableShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Referable/checksum> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -1094,7 +1094,7 @@ aas:ResourceShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Resource/path> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -1103,7 +1103,7 @@ aas:ResourceShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/Resource/contentType> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -1117,7 +1117,7 @@ aas:SpecificAssetIdShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/name> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -1125,7 +1125,7 @@ aas:SpecificAssetIdShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/SpecificAssetId/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:minLength 1 ;
@@ -1192,7 +1192,7 @@ aas:SubmodelElementListShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/SubmodelElementList/orderRelevant> ;
-        sh:datatype xsd:boolean ;
+        sh:datatype xs:boolean ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -1240,7 +1240,7 @@ aas:ValueReferencePairShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <http://www.admin-shell.io/aas/3/0/RC02/ValueReferencePair/value> ;
-        sh:datatype xsd:string ;
+        sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;


### PR DESCRIPTION
We used ``xsd:`` in RDF+SHACL and ``xs:`` in XSD. This change makes it
uniform, and we use ``xs:`` everywhere.

We used:
* [aas-core-meta 8d909e9],
* [aas-core-codegen 6bb8ccf], and
* [aas-core3.0rc02-testgen acaa7ab4].

[aas-core-meta 8d909e9]: https://github.com/aas-core-works/aas-core-meta/commit/8d909e9
[aas-core-codegen 6bb8ccf]: https://github.com/aas-core-works/aas-core-codegen/commit/6bb8ccf
[aas-core3.0rc02-testgen acaa7ab4]: https://github.com/aas-core-works/aas-core3.0rc02-testgen/commit/acaa7ab4