### PR TITLE
Restrict `ValueDataType` to `xs:string` in XML

### DIFF
--- a/.github/workflows/check-title-and-description-of-pull-request.yml
+++ b/.github/workflows/check-title-and-description-of-pull-request.yml
@@ -11,7 +11,9 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the title and description of the pull request
-        uses: mristin/opinionated-commit-message@v2.3.2
+        uses: mristin/opinionated-commit-message@v3.0.0
+        with:
+          path-to-additional-verbs: AdditionalVerbsInImperativeMood.txt
 
       - name: READ HERE ON FAILURE FOR MORE INSTRUCTIONS
         if: ${{ failure() }}

--- a/AdditionalVerbsInImperativeMood.txt
+++ b/AdditionalVerbsInImperativeMood.txt
@@ -1,0 +1,25 @@
+unit test
+integration test
+rewrap
+unwrap
+re-wrap
+undo
+re-do
+inline
+in-line
+assign
+standardize
+verbosify
+log
+integrate
+enhance
+untrack
+refine
+dispatch
+export
+skip
+redirect
+deduplicate
+re-order
+position
+restrict

--- a/schemas/xml/AAS.xsd
+++ b/schemas/xml/AAS.xsd
@@ -1098,7 +1098,7 @@
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="valueDataType">
-    <xs:union memberTypes="xs:anyURI xs:base64Binary xs:boolean xs:date xs:dateTime xs:dateTimeStamp xs:decimal xs:double xs:duration xs:float xs:gDay xs:gMonth xs:gMonthDay xs:gYear xs:gYearMonth xs:hexBinary xs:string xs:time xs:dayTimeDuration xs:yearMonthDuration xs:integer xs:long xs:int xs:short xs:byte xs:nonNegativeInteger xs:positiveInteger xs:unsignedLong xs:unsignedInt xs:unsignedShort xs:unsignedByte xs:nonPositiveInteger xs:negativeInteger"/>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:complexType name="administrativeInformation_t">
     <xs:sequence>


### PR DESCRIPTION
We restrict the constrained simple type `ValueDataType` to `xs:string`
to make the schema compatible with XSD 1.0. Previously, we used a union
corresponding to `DataTypeDefXSD` which was only compatible with
XSD 1.1.