### PR TITLE
Fix abbreviations in labels of RDF schema

### DIFF
--- a/schemas/rdf/rdf-ontology.ttl
+++ b/schemas/rdf/rdf-ontology.ttl
@@ -508,7 +508,7 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has din notation"^^xs:string ;
+    rdfs:label "has DIN notation"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
     rdfs:range xs:string ;
     rdfs:comment "Notation of physical unit conformant to DIN"@en ;
@@ -516,7 +516,7 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has ece code"^^xs:string ;
+    rdfs:label "has ECE code"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
     rdfs:range xs:string ;
     rdfs:comment "Code of physical unit conformant to ECE"@en ;
@@ -524,7 +524,7 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has ece name"^^xs:string ;
+    rdfs:label "has ECE name"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
     rdfs:range xs:string ;
     rdfs:comment "Name of physical unit conformant to ECE"@en ;
@@ -532,7 +532,7 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has nist name"^^xs:string ;
+    rdfs:label "has NIST name"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
     rdfs:range xs:string ;
     rdfs:comment "Name of NIST physical unit"@en ;
@@ -548,7 +548,7 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has si name"^^xs:string ;
+    rdfs:label "has SI name"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
     rdfs:range xs:string ;
     rdfs:comment "Name of SI physical unit"@en ;
@@ -556,7 +556,7 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has si notation"^^xs:string ;
+    rdfs:label "has SI notation"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
     rdfs:range xs:string ;
     rdfs:comment "Notation of SI physical unit"@en ;
@@ -637,7 +637,7 @@ aas:DataTypeDefXsd rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri
 <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri> rdf:type aas:DataTypeDefXsd ;
-    rdfs:label "Any Uri"^^xs:string ;
+    rdfs:label "Any URI"^^xs:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Base64Binary
@@ -852,7 +852,7 @@ aas:DataTypeIEC61360 rdf:type owl:Class ;
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Html
 <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Html> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Html"^^xs:string ;
+    rdfs:label "HTML"^^xs:string ;
     rdfs:comment "Values containing string with any sequence of characters, using the syntax of HTML5 (see W3C Recommendation 28:2014)"@en ;
 .
 


### PR DESCRIPTION
The abbreviations in the labels of RDF schema were not properly upper-cased due to an omission in aas-core-meta and aas-core-codegen.

We fixed the issue in aas-core-codegen, and propagate the changes in this patch.

We used [aas-core-codegen 1cff35bd] and [aas-core-meta d180dbb].

[aas-core-codegen 1cff35bd]: https://github.com/aas-core-works/aas-core-codegen/commit/1cff35bd
[aas-core-meta d180dbb]: https://github.com/aas-core-works/aas-core-meta/commit/d180dbb