### PR TITLE
Add missing `environment` element in XSD-schema

### DIFF
--- a/schemas/xml/AAS.xsd
+++ b/schemas/xml/AAS.xsd
@@ -1339,4 +1339,5 @@
       <xs:group ref="valueReferencePair"/>
     </xs:sequence>
   </xs:complexType>
+  <xs:element name="environment" type="environment_t"/>
 </xs:schema>


### PR DESCRIPTION
The current XSD-schema misses
`<xs:element name="environment" type="environment_t" />` 
at the end of the file, as stated in #261.

We fix this by adding the missing element to the schema.

Fixes #261