### PR TITLE
Fix CI for netcore 3.1

### DIFF
--- a/.github/workflows/check-schemas-and-examples.yml
+++ b/.github/workflows/check-schemas-and-examples.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Install netcore 3.1 (needed for schema validation)
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '3.1.x'
+
       - name: Install schema-validation
         working-directory: schemas
         run: powershell .\InstallSchemaValidation.ps1


### PR DESCRIPTION
The GitHub's image `windows-latest` deprecated netcore 3.1, which is
used by the validation utilities.

In this patch, we explicitly install in the CI workflow netcore 3.1.