### PR TITLE
Move ValueOnly etc. from Part 2 to Part 1

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/nav.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/nav.adoc
@@ -40,6 +40,9 @@ include::./IDTA-01001.adoc[]
 
 include::./IDTA-01001_DataSpecifications.adoc[]
 
+
+include::./IDTA-01001_GrammarSemanticIdsMetamodel.adoc[]
+
 include::./IDTA-01001_Mappings.adoc[]
 
 include::./IDTA-01001_SummaryOutlook.adoc[]
@@ -49,6 +52,8 @@ include::./IDTA-01001_SummaryOutlook.adoc[]
 include::./Annex/IDTA-01001_ConceptsAAS.adoc[]
 
 include::./Annex/IDTA-01001_Requirements.adoc[]
+
+include::./Annex/IDTA-01001_ValueOnlySerializationExample.adoc[]
 
 include::Shared:Annex/IDTA-01xxx_BackusNaurForm.adoc[]
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/Annex/IDTA-01001_ValueOnlySerializationExample.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Annex/IDTA-01001_ValueOnlySerializationExample.adoc
@@ -1,0 +1,164 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
+
+[appendix]
+== ValueOnly-Serialization Example 
+
+The following example shows the ValueOnly-Serialization for an entire Submodel that validates against the JSON-schema specified in Clause 11.4.3. +
+As mentioned in Clause 11.4.3, __SubmodelElementCollection__s cannot be validated within the same schema due to circularity reasons; instead they have their own specific validation schema. An exemplary _SubmodelElementCollection_ is added to the following JSON for completeness. It is, however, not validatable against the schema in Clause 11.4.3 due to the reasons mentioned above.
+
+[source,json,linenums]
+----
+{
+  "MyPropertyIdShortNumber": 5000,
+  "MyPropertyIdShortString": "MyTestStringValue",
+  "MyPropertyIdShortBoolean": true,
+  "MyMultiLanguageProperty": [
+    {
+      "de": "Das ist ein deutscher Bezeichner"
+    },
+    {
+      "en": "That's an English label"
+    }
+  ],
+  "MyRange": {
+    "min": 3,
+    "max": 15
+  },
+  "MyFile": {
+    "contentType": "application/pdf",
+    "value": "SafetyInstructions.pdf"
+  },
+  "MyBlob": {
+    "contentType": "application/octet-stream",
+    "value": "VGhpcyBpcyBteSBibG9i"
+  },
+  "MyEntity": {
+    "statements": {
+      "MaxRotationSpeed": 5000
+    },
+    "entityType": "SelfManagedEntity",
+    "globalAssetId": "http://customer.com/demo/asset/1/1/MySubAsset"
+  },
+  "MyReference": {
+    "type": "ModelReference",
+    "keys": [
+      {
+        "type": "Submodel",
+        "value": "http://customer.com/demo/aas/1/1/1234859590"
+      },
+      {
+        "type": "Property",
+        "value": "MaxRotationSpeed"
+      }
+    ]
+  },
+  "MyBasicEvent": {
+    "observed": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "CurrentValue"
+        }
+      ]
+    }
+  },
+  "MyRelationship": {
+    "first": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "PlusPole"
+        }
+      ]
+    },
+    "second": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/0/1234859123490"
+        },
+        {
+          "type": "Property",
+          "value": "MinusPole"
+        }
+      ]
+    }
+  },
+  "MyAnnotatedRelationship": {
+    "first": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "PlusPole"
+        }
+      ]
+    },
+    "second": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/0/1234859123490"
+        },
+        {
+          "type": "Property",
+          "value": "MinusPole"
+        }
+      ]
+    },
+    "annotation": [
+      {
+        "AppliedRule": "TechnicalCurrentFlowDirection"
+      }
+    ]
+  },
+  "MySubmodelElementIntegerPropertyList": [
+    1,
+    2,
+    30,
+    50
+  ],
+  "MySubmodelElementFileList": [
+    {
+      "contentType": "application/pdf",
+      "value": "MyFirstFile.pdf"
+    },
+    {
+      "contentType": "application/pdf",
+      "value": "MySecondFile.pdf"
+    }
+  ],
+  "MySubmodelElementCollection":
+  {
+    "myStringElement": "That’s a string",
+    "myIntegerElement": 5,
+    "myBooleanElement": true
+  }
+}
+----

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_DataSpecifications.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_DataSpecifications.adoc
@@ -1,3 +1,14 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
 
 == Data Specification Templates (normative)
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_GrammarSemanticIdsMetamodel.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_GrammarSemanticIdsMetamodel.adoc
@@ -1,6 +1,6 @@
-////
-====  Semantic Identifiers for Metamodel and Data Specifications
-////
+
+==  Semantic Identifiers for Metamodel and Data Specifications
+
 
 
 Rules for creating identifiers are defined to enable the unique identification of concepts as used and defined in the metamodel of the Asset Administration Shell.

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_Mappings.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_Mappings.adoc
@@ -1,6 +1,19 @@
-== Mappings to Data Formats to Share I4.0-Compliant Information (normative)
+////
+Copyright (c) 2023 Industrial Digital Twin Association
 
-=== General
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
+
+
+== Data Format for Sharing Data (normative)
+
+=== Technical Data Formats
 
 It is crucial for Industry 4.0 applications to share information between different systems throughout the areas covered by the entire RAMI4.0 model link:#bib1[[1\]] link:#bib2[[2\]]. OPC UA is a frequently used format for information models in the domain of production operations, but there is a need for other formats for further areas and the relationships between them.
 
@@ -27,32 +40,67 @@ Note: the mapping specifications and schemata themselves are not part of the spe
 ====
 
 
-===  General Rules
+=== Content Format Types
 
-====  Introduction
+For different use case scenarios different formats are suitable to fulfill the needs.
+Besides technical formats like JSON and XML also different content formats are available.
 
-There are some general rules that apply to all serializations or can be used in different serializations.
 
-====  Encoding
+.Format Types
+[%autowidth, width="100%", cols="29%,71%",options="header",]
+|===
+|*Format* |*Explanation*
+|Normal a|The standard serialization of the model element or child elements is applied.
+
+|Metadata a|Only metadata of an element or child elements is returned; the value is not.
+
+|Value a|Only the raw value of the model element or child elements is returned; it is commonly referred to as _ValueOnly_-serialization.
+
+|Reference |Only applicable to Referables. Only the reference to the found element is returned; potential child elements are ignored.
+
+|Path a|Returns the idShort of the requested element and a list of _idShort_ paths to child elements if the requested element is a Submodel, a SubmodelElementCollection, a SubmodelElementList, a AnnotatedRelationshipElement, or an Entity.
+|===
+
+
+===  Encoding
 
 Blobs require the following encoding: base64 string.
 
-====  Serialization of Values of Type "Reference"
+
+===  Serialization of Values of Type "Reference"
 
 include::IDTA-01001_GrammarSerializationReference.adoc[]
 
 
-====  Semantic Identifiers for Metamodel and Data Specifications
+include::./IDTA-01001_MetaDataObjects.adoc[]
 
-include::IDTA-01001_GrammarSemanticIdsMetamodel.adoc[]
+include::IDTA-01001_ValueOnly.adoc[]
 
+include::IDTA-01001_idShortPath.adoc[]
 
-====  Embedded Data Specifications
+=== Format "Reference"
 
-include::IDTA-01001_EmbeddedDataSpecifications.adoc[]
+In some use cases only the (model) reference to the object is needed in the first place.
 
+References are possible for Referables, only. Potential child elements are ignored.
 
-===  XML
+For references see Clause xref:#_referencing_in_asset_administration_shells[].
+
+.Format "Reference" - Example in JSON
+[source,json,linenums]
+----
+        "keys": [
+          {
+            "type": "AssetAdministrationShell",
+            "value": "urn:an-example08:f3f73640"
+          }
+        ],
+        "type": "ModelReference"
+      }
+
+----
+
+=== Format "Normal" in  XML
 
 The metamodel of an Asset Administration Shell needs to be serialized for import and export scenarios. XML is a possible serialization format.
 
@@ -76,7 +124,7 @@ Note 3: example files can be found here: aas-specs-3.0\schemas\xml\examples
 ====
 
 
-===  JSON
+===  Format "Normal" in JSON
 
 JSONfootnote:[see: https://tools.ietf.org/html/rfc8259 or https://www.ecma-international.org/publications/standards/Ecma-404.htm] (JavaScript Object Notation) is a further serialization format that serializes the metamodel of an Asset Administration Shell for import and export scenarios.
 
@@ -100,7 +148,7 @@ Note 3: example files can be found here: aas-specs-3.0\schemas\json\examples
 ====
 
 
-===  RDF
+===  Format "Normal" in RDF
 
 The Resource Description Framework (RDF) link:#bib32[[32\]] is the recommended standard of the W3C to unambiguously model and present semantic data. RDF documents are structured in the form of triples, consisting of subjects, relations, and objects. The resulting model is often interpreted as a graph, with the subject and object elements as the nodes and the relations as the graph edges.
 
@@ -128,7 +176,7 @@ Note 3: example files can be found here: aas-specs-3.0\schemas\rdf\examples
 ====
 
 
-===  AutomationML
+===  Format "Normal" in AutomationML
 
 AutomationML (IEC 62714) is especially suited for serializing the import and export scenarios of the metamodel of an Asset Administration Shell in the engineering phase.
 
@@ -154,7 +202,7 @@ Note 2: the resulting application recommendation (AR 004E) "Asset Administration
 ====
 
 
-===  OPC UA
+===  Format "Normal" in OPC UA
 
 OPC UA is suited for the operating phase of Asset Administration Shellsfootnote:[OPC UA is used for several purposes in the context of Industry 4.0. In this document, however, the focus is on Asset Administration Shell representation only.] and especially applicable in case of machine-to-machine communication. The information model link:#bib42[[42\]] is the basis for the definition of so-called OPC UA Information Models, or OPC UA Companion Specifications link:#bib43[[43\]].
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_MetaDataObjects.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_MetaDataObjects.adoc
@@ -1,0 +1,86 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
+
+
+=== Format "Metadata" (Metadata-Serialization)
+
+
+Metadata objects are defined for scenarios where a client only wants to access the metadata of an object, but not the value. *Metadata objects are only part of HTTP/REST and do not change the metamodel.* Metadata objects are used to reduce the payload response to a minimum and to avoid the recursive traversing through the data model when not needed. In many cases, a client is not interested in each child element or value of a resource, but only in the resource itself.
+
+A metadata object does not contain any additional fields in relation to its full object representation, only some fields are left off. The left off fields are fields which could be requested by an own API call and may consist of a recursive or potentially large substructure. The serialization of a metadata object is the same as for the original full object, but without the left off fields.
+
+.Metadata Attributes
+[%autowidth, width="100%", cols="48%,52%",options="header",]
+|===
+|*Class Name* |*Fields not available in metadata representation*
+2+|*Identifiables*
+|AssetAdministrationShell |assetInformation, submodels
+|Submodel |submodelElements
+2+|*SubmodelElements*
+|SubmodelElementCollection |value
+|SubmodelElementList |value
+|Entity |statements, globalAssetId, specificAssetId
+|BasicEventElement |observed
+|Capability |--
+|Operation |--
+2+|*DataElements*
+|Property |value, valueId
+|MultilanguageProperty |value, valueId
+|Range |min, max
+|ReferenceElement |value
+|RelationshipElement |first, second
+|AnnotatedRelationshipElement |first, second, annotations
+|Blob |value, contentType
+|File |value, contentType
+|===
+
+
+*Example*
+
+The example shows a JSON serialization of an AssetAdministrationShell object in its full representation and how it looks like in a metadata representation.
+
+
+====
+Note: for editorial reasons, some fields which are the same for both representations are omitted.
+====
+
+.AssetAdministrationShell JSON Serialization Example
+|===
+a|
+[source,json,linenums]
+----
+{
+    "idShort": "TestAssetAdministrationShell",
+    "description": [...],
+    "id": {...},
+     ...
+    "derivedFrom": {...}
+    "assetInformation": {...},
+    "submodels": [...]
+}
+----
+|===
+
+.AssetAdministrationShell Metadata JSON Serialization Example
+|===
+a|
+[source,json,linenums]
+----
+{
+  "idShort": "TestAssetAdministrationShell",
+  "description": [...],
+  "id": {...},
+  ...
+  "derivedFrom": {...},
+}
+----
+|===

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ValueOnly.adoc
@@ -1,0 +1,743 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
+
+////
+==== Serialization in Specified Formats (SerializationModifier _Content_)
+////
+
+
+
+
+
+
+=== Format "Value" (ValueOnly-Serialization) in JSON
+
+
+In many cases, applications using data from Asset Administration Shells already know the Submodel regarding its structure, attributes, and semantics. Consequently, there is not always a need to receive the entire model information, which can be requested separately via _Content_ modifier set to _Metadata_, in each request since it is constant most of the time. Instead, applications are most likely only interested in the values of the modelled data. Furthermore, having limited processing power or limited bandwidth, one use case of this SerializationModifier is to transfer data as efficiently as possible. Semantics and data might be split into two separate architecture building blocks. For example, a database would suit the needs for querying semantics, while a device would only provide the data at runtime. Two separate requests make it possible to build up a user interface (UI) and show new upcoming values highly efficiently.
+
+Values are only available for
+
+* All subtypes of abstract type _DataElement_,
+* SubmodelElementList and SubmodelElementCollection resp. for their included SubmodelElements,
+* ReferenceElement,
+* RelationshipElement + AnnotatedRelationshipElement,
+* Entity,
+* BasicEventElement.
+
+Capabilities are excluded from the SerializationModifier’s scope since only data containing elements are in the focus. They are consequently omitted in the serialization.
+
+The following rules shall be adhered to when serializing a submodel with the SerializationModifier _Value_:
+
+* A submodel is serialized as an unnamed JSON object.
+* A submodel element is considered a leaf submodel element if it does not contain other submodel elements. A leaf submodel element follows the rules for the different submodel elements considered in the serialization, as described below. If it is not a leaf element, the serialization rules must be transitively followed until the value is a leaf submodel element.
+* For each submodel element:
+** _Property_ is serialized as $\{Property/idShort}: $\{Property/value} where $\{Property/value} is the JSON serialization of the respective property’s value in accordance with the data type to value mapping (see table after this section).
+** _MultiLanguageProperty_ is serialized as named JSON object with $\{MultiLanguageProperty/idShort} as the name of the containing JSON property. The JSON object contains an array of JSON objects for each language of the _MultiLanguageProperty_ with the language as name and the corresponding localized string as value of the respective JSON property. The language name is defined as two chars according to ISO 639-1.
+** _Range_ is serialized as named JSON object with $\{Range/idShort} as the name of the containing JSON property. The JSON object contains two JSON properties. The first is named “min”. The second is named “max”. Their corresponding values are $\{Range/min} and $\{Range/max}.
+** _File_ and _Blob_ are serialized as named JSON objects with $\{File/idShort} or $\{Blob/idShort}as the name of the containing JSON property. The JSON object contains two JSON properties. The first refers to the content type named $\{File/contentType} resp. $\{Blob/contentType}. The latter refers to the value named “value” $\{File/value} resp. $\{Blob/value}. The resulting ValueOnly object is indistinguishable whether it contains File or Blob attributes. Therefore, the receiver needs to take the type of the target resource into account. Since the receiver knows in advance if a File or a Blob SubmodelElement shall be manipulated, it can parse the transferred ValueOnly object accordingly as a File or Blob object.
+** _SubmodelElementCollection_ is serialized as named JSON object with $\{SubmodelElementCollection/idShort} as the name of the containing JSON property. The elements contained within the struct are serialized according to their respective type with $\{SubmodelElement/idShort} as the name of the containing JSON property.
+** _SubmodelElementList_ is serialized as a JSON array with the index of the contained SubmodelElement in the list as the position in the JSON array. The elements contained within the list are serialized according to their respective type.
+** _ReferenceElement_ is serialized as $\{ReferenceElement/idShort}: $\{ReferenceElement/value} where $\{ReferenceElement/value} is the serialization of the _Reference_ class.
+** _RelationshipElement_ is serialized as named JSON object with $\{RelationshipElement/idShort} as the name of the containing JSON property. The JSON object contains two JSON properties. The first is named “first”. The second is named “second”. Their corresponding values are $\{RelationshipElement/first} resp. $\{Relationship/second}. The values are serialized according to the serialization of a _ReferenceElement_ (see above).
+** _AnnotatedRelationshipElement_ is serialized according to the serialization of a _ReleationshipElement_ (see above). Additionally, a third named JSON object is introduced with “annotations” as the name of the containing JSON property. The value is $\{AnnotatedRelationshipElement/annotations}. The values of the array items are serialized depending on the type of the annotation data element.
+** _Entity_ is serialized as named JSON object with $\{Entity/idShort} as the name of the containing JSON property. The JSON object contains three JSON properties. The first is named “statements” $\{Entity/statements} and contains an array of the serialized submodel elements according to their respective serialization mentioned in this clause. The second is named either “globalAssetId” or “specificAssetId” and contains either a _Reference_ (see above) or a _SpecificAssetId_. The third property is named “entityType” and contains a string representation of $\{Entity/entityType}.
+** _BasicEventElement_ is serialized as named JSON object with $\{BasicEventElement/idShort} as the name of the containing JSON property. The JSON object contains one JSON property named “observed” with the corresponding value of $\{BasicEventElement/observed} as the standard serialization of the _Reference_ class.
+** _SpecificAssetId_ is serialized as named JSON object with three JSON properties named as the attributes of _SpecificAssetId._
+
+* Submodel elements defined in the submodel other than the ones mentioned above are not subject to serialization of that SerializationModifier.
+
+*Data type to value mapping* footnote:[cf. https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/2.0.0/datatypes.html]
+
+The serialization of submodel element values is described in the following table. The left column “Data Type” shows the data types which can be used for submodel element values. The data types are defined according to the W3C XML Schema (https://www.w3.org/TR/xmlschema-2/#built-in-datatypes and https://www.w3.org/TR/xmlschema-2/#built-in-derived). “Value Range” further explains the possible range of data values for this data type. The right column comprises related examples of the serialization of submodel element values.
+
+.Mapping of Data Types in ValueOnly-Serialization
+[%autowidth, width="100%", cols="15%,15%,9%,30%,31%",options="header",]
+|===
+| |*Data Type* |*JSON Type* |*Value Range* |*Sample Values*
+|Core Types |xs:string |string |Character string |"Hello world", "Καλημέρα κόσμε", "コンニチハ"
+| |xs:boolean |boolean |true, false |true, false
+| |xs:decimal |number |Arbitrary-precision decimal numbers |-1.23, 126789672374892739424.543233, 100000.00, 210
+| |xs:integer |number |Arbitrary-size integer numbers |-1, 0, 126789675432332938792837429837429837429, 100000
+|IEEE-floating-point numbers |xs:double |number |64-bit floating point numbers |-1.0, -0.0, 0.0, 234.567e8, 234.567e+8, 234.567e-8
+| |xs:float |number |32-bit floating point numbers |-1.0, -0.0, 0.0, 234.567e8, 234.567e+8, 234.567e-8
+|Time and data |xs:date |string |Dates (yyyy-mm-dd) with or without time zone |"2000-01-01","2000-01-01Z", "2000-01-01+12:05"
+| |xs:time |string |Times (hh:mm:ss.sss…​) with or without time zone |"14:23:00", "14:23:00.527634Z", "14:23:00+03:00"
+| |xs:dateTime |string |Date and time with or without time zone |"2000-01-01T14:23:00", "2000-01-01T14:23:00.66372+14:00"
+| |xs:dateTimeStamp |string |Date and time with required time zone |"2000-01-01T14:23:00.66372+14:00"
+|Recurring and partial dates |xs:gYear |string |Gregorian calendar year |"2000", "2000+03:00"
+| |xs:gMonth |string |Gregorian calendar month |"--04", "--04+03:00"
+| |xs:gDay |string |Gregorian calendar day of the month |"---04", "---04+03:00"
+| |xs:gYearMonth |string |Gregorian calendar year and month |"2000-01", "2000-01+03:00"
+| |xs:gMonthDay |string |Gregorian calendar month and day |"--01-01", "--01-01+03:00"
+| |xs:duration |string |Duration of time |"P30D", "-P1Y2M3DT1H", "PT1H5M0S"
+| |xs:yearMonthDuration |string |Duration of time (months and years only) |"P10M", 'P5Y2M"
+| |xs:dayTimeDuration |string |Duration of time (days, hours, minutes, seconds only) |"P30D", 'P1DT5H", 'PT1H5M0S"
+|Limited-range integer numbers |xs:byte |number |-128…+127 (8 bit) |-1, 0, 127
+| |xs:short |number |-32768…+32767 (16 bit) |-1, 0, 32767
+| |xs:int |number |2147483648…+2147483647 (32 bit) |-1, 0, 2147483647
+| |xs:long |number |-9223372036854775808…+9223372036854775807 (64 bit) |-1, 0, 9223372036854775807
+| |xs:unsignedByte |number |0…255 (8 bit) |0, 1, 255
+| |xs:unsignedShort |number |0…65535 (16 bit) |0, 1, 65535
+| |xs:unsignedInt |number |0…4294967295 (32 bit) |0, 1, 4294967295
+| |xs:unsignedLong |number |0…18446744073709551615 (64 bit) |0, 1, 18446744073709551615
+| |xs:positiveInteger |number |Integer numbers >0 |1, 7345683746578364857368475638745
+| |xs:nonNegativeInteger |number |Integer numbers ≥0 |0, 1, 7345683746578364857368475638745
+| |xs:negativeInteger |number |Integer numbers <0 |-1, -23487263847628376482736487263847
+| |xs:nonPositiveInteger |number |Integer numbers ≤0 |-1, 0, -93845837498573987498798987394
+|Encoded binary data |xs:hexBinary |string |Hex-encoded binary data |"6b756d6f77617368657265"
+| |xs:base64Binary |string |base64-encoded binary data |"a3Vtb3dhc2hlcmU="
+|Miscellaneous types |xs:anyURI |string |Absolute or relative URIs and IRIs |"http://customer.com/demo/aas/1/1/1234859590", "urn:example:company:1.0.0"
+| |rdf:langString |string |Strings with language tags a|
+"'Hello'@en", "'Hallo'@de"
+
+
+====
+Note: the examples are written in RDF/Turtle syntax, and only "Hello" and "Hallo" are the actual values.
+====
+
+
+|===
+
+The following types defined by the XSD and RDF specifications are explicitly omitted for serialization:
+
+xs:language, xs:normalizedString, xs:token, xs:NMTOKEN, xs:Name, xs:NCName, xs:QName, xs:ENTITY, xs:ID, xs:IDREF, xs:NOTATION, xs:IDREFS, xs:ENTITIES, xs:NMTOKENS, rdf:HTML and rdf:XMLLiteral.
+
+
+====
+Note 1: due to the limits in the representation of numbers in JSON, the maximum integer number that can be used without losing precision is 2⁵³-1 (defined as Number.MAX_SAFE_INTEGER). Even if the used data type would allow higher or lower values, they cannot be used if they cannot be represented in JSON. Affected data types are unbounded numeric types xs:decimal, xs:integer, xs:positiveInteger, xs:nonNegativeInteger, xs:negativeInteger, xs:nonPositiveInteger and the bounded type xs:unsignedLong. Other numeric types are not affected. footnote:[cf. https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html (with adjustments for +/-INF, NaN, and language-typed literal support)]
+====
+
+
+
+====
+Note 2: the ValueOnly-serialization uses JSON native data types, AAS in general uses XML Schema Built-in Datatypes for Simple Data Types and ValueDataType. In case of booleans, JSON accepts only literals true and false, whereas xs:boolean also accepts 1 and 0, respectively. In case of double, JSON number is used in ValueOnly, but JSON number does not support INF/-INF (positive Infinity/negative), which is supported by xs:double. Furthermore, NaN (Not a Number) is also not supported. +
+====
+
+(See https://datatracker.ietf.org/doc/html/rfc8259#section-6 )
+
+
+====
+Note 3: language-tagged strings (rdf:langString) containing single quotes (‘) or double quotes (“) are not supported.
+====
+
+
+*Examples conformant to link:#bib1[[1\]]:*
+
+Full serialization of single submodel element _Property_:
+
+[source,json,linenums]
+----
+{
+  "idShort": "MaxRotationSpeed",
+  "category": "PARAMETER",
+  "kind": "Instance",
+  "semanticlId": {
+    "type": "ModelReference",
+    "keys": [
+      {
+        "type": "ConceptDescription",
+        "value": "0173-1#02-BAA120#008"
+      }
+    ]
+  },
+  "modelType": "Property",
+  "valueType": "xs:int",
+  "value": "5000"
+}
+----
+
+With the SerializationModifier set to _Value,_ the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "MaxRotationSpeed": 5000
+}
+----
+
+TODO: Example where precision in value string to ValueOnly to value string is critical.
+
+
+For a _SubmodelElementCollection,_ the struct is serialized as objects denoted by curly brackets:
+
+[source,json,linenums]
+----
+{
+  "NamesOfFamilyMembers": {
+    "NameOfMother": "Martha ExampleFamily",
+    "NameOfFather": "Jonathan ExampleFamily",
+    "NameOfSon": "Clark ExampleFamily"
+  }
+}
+----
+
+For a _SubmodelElementList,_ the struct is serialized as array denoted by square brackets:
+
+[source,json,linenums]
+----
+{
+  "NamesOfFamilyMembers": [
+    "Martha ExampleFamily",
+    "Jonathan ExampleFamily",
+    "Clark ExampleFamily"
+  ]
+}
+----
+
+For a _MultiLanguageProperty_ named “Label”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "Label": [
+    {"de": "Das ist ein deutscher Bezeichner"},
+    {"en": "That's an English label"}
+  ]
+}
+----
+
+
+====
+Note: in accordance with IETF https://tools.ietf.org/html/rfc5646#page-5[RFC 5646], the language names match the following regular expression:
+====
+
+
+[source]
+----
+^[a-z]\{2,4}(-[A-Z][a-z]\{3})?(-([A-Z]\{2}|[0-9]\{3}))?$
+----
+
+
+For a _Range_ named “TorqueRange”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "TorqueRange": {
+    "min": 3,
+    "max": 15
+  }
+}
+----
+
+For a _ReferenceElement_ named “MaxRotationSpeedReference”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "MaxRotationSpeedReference": {
+    "type": "ModelReference",
+    "keys": [
+      {
+        "type": "Submodel",
+        "value": "http://customer.com/demo/aas/1/1/1234859590"
+      },
+      {
+        "type": "Property",
+        "value": "MaxRotationSpeed"
+      }
+    ]
+  }
+}
+----
+
+For the same _ReferenceElement,_ the payload is minimized to the following in case the _Reference_ is of subtype _GlobalReference_:
+
+[source,json,linenums]
+----
+{
+  "MaxRotationSpeedReference": {
+    "type": "ExternalReference",
+    "keys": [
+      {
+        "type": "GlobalReference",
+        "value": "0173-1#02-BAA120#008"
+      }
+    ]
+  }
+}
+----
+
+For a _File_ named “Document”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "Document": {
+    "contentType": "application/pdf",
+    "value": "SafetyInstructions.pdf"
+  }
+}
+----
+
+For a _Blob_ named “Library”, the payload is minimized to the following if the SerializationModifier _Extent_ is set to *_WithoutBLOBValue_*
+
+[source,json,linenums]
+----
+{
+  "Library": {
+    "contentType": "application/octet-stream"
+  }
+}
+----
+
+If the SerializationModifier Extent is set to *_WithBlobValue_*, there is an additional attribute containing the base64-encoded value:
+
+[source,json,linenums]
+----
+{
+  "Library": {
+    "contentType": "application/octet-stream",
+    "value": "VGhpcyBpcyBteSBibG9i"
+  }
+}
+----
+
+For a _RelationshipElement_ named “CurrentFlowsFrom”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "CurrentFlowsFrom": {
+    "first": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "PlusPole"
+        }
+      ]
+    },
+    "second": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/0/1234859123490"
+        },
+        {
+          "type": "Property",
+          "value": "MinusPole"
+        }
+      ]
+    }
+  }
+}
+----
+
+For an _AnnotatedRelationshipElement_ named “CurrentFlowFrom”, with an annotated _Property_-DataElement “AppliedRule”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "CurrentFlowsFrom": {
+    "first": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "PlusPole"
+        }
+      ]
+    },
+    "second": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/0/1234859123490"
+        },
+        {
+          "type": "Property",
+          "value": "MinusPole"
+        }
+      ]
+    },
+    "annotation": [
+      {
+        "AppliedRule": "TechnicalCurrentFlowDirection"
+      }
+    ]
+  }
+}
+----
+
+For an _Entity_ named “MySubAssetEntity”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "MySubAssetEntity": {
+    "statements": {
+      "MaxRotationSpeed": 5000
+    },
+    "entityType": "SelfManagedEntity",
+    "globalAssetId": {
+      "type": "ExternalReference",
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "http://customer.com/demo/asset/1/1/MySubAsset"
+        }
+      ]
+    }
+  }
+}
+----
+
+For a BasicEventElement named “MyBasicEvent”, the payload is minimized to the following:
+
+[source,json,linenums]
+----
+{
+  "MyBasicEvent": {
+    "observed": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "CurrentValue"
+        }
+      ]
+    }
+  }
+}
+----
+
+===== JSON-Schema for the ValueOnly-Serialization
+
+The following JSON-Schema represents the validation schema for the ValueOnly-Serialization of submodel elements. This holds true for all submodel elements mentioned in the previous clause except for _SubmodelElementCollections_. Since _SubmodelElementCollections_ are treated as objects containing submodel elements of any kind, the integration into the same validation schema would result in a circular reference or ambiguous results ignoring the actual validation of submodel elements other than _SubmodelElementCollections_. Hence, the same validation schema must be applied for each _SubmodelElementCollection_ within a submodel element hierarchy. In this case, it may be necessary to create a specific JSON-Schema for the individual use case. The _SubmodelElementCollection_ is added to the following schema for completeness and clarity. It is, however, not referenced from the _SubmodelElementValue_-oneOf-Enumeration due to the reasons mentioned above. +
+See Annex B for an example that validates against this schema.
+
+[source,json,linenums]
+----
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ValueOnly-Serialization-Schema",
+  "$id": "https://admin-shell.io/schema/valueonly/json/V3.0",
+  "definitions": {
+    "AnnotatedRelationshipElementValue": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "$ref": "#/definitions/ReferenceValue"
+        },
+        "second": {
+          "$ref": "#/definitions/ReferenceValue"
+        },
+        "annotation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValueOnly"
+          }
+        }
+      },
+      "required": [
+        "first",
+        "second",
+        "annotation"
+      ],
+      "additionalProperties": false
+    },
+    "BasicEventElementValue": {
+      "type": "object",
+      "properties": {
+        "observed": {
+          "$ref": "#/definitions/ReferenceValue"
+        }
+      },
+      "required": [
+        "observed"
+      ],
+      "additionalProperties": false
+    },
+    "BlobValue": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "minLength": "1",
+          "maxLength": "100"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "contentType",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "BooleanValue": {
+      "type": "boolean",
+      "additionalProperties": false
+    },
+    "EntityValue": {
+      "type": "object",
+      "properties": {
+        "statements": {
+          "$ref": "#/definitions/ValueOnly"
+        },
+        "entityType": {
+          "enum": [
+            "SelfManagedEntity",
+            "CoManagedEntity"
+          ]
+        },
+        "globalAssetId": {
+          "type": "string"
+        },
+        "specificAssetIds": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SpecificAssetIdValue"
+          }
+        }
+      },
+      "required": [
+        "statements",
+        "entityType"
+      ],
+      "additionalProperties": false
+    },
+    "FileValue": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "minLength": "1",
+          "maxLength": "100"
+        },
+        "value": {
+          "type": "string",
+          "minLength": "1",
+          "maxLength": "200"
+        }
+      },
+      "required": [
+        "contentType",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "Identifier": {
+      "type": "string"
+    },
+    "Key": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "LangString": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z]{2,4}(-[A-Z][a-z]{3})?(-([A-Z]{2}|[0-9]{3}))?$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "MultiLanguagePropertyValue": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LangString"
+      },
+      "additionalProperties": false
+    },
+    "NumberValue": {
+      "type": "number",
+      "additionalProperties": false
+    },
+    "OperationRequestValueOnly": {
+      "inoutputArguments": {
+        "$ref": "#/definitions/ValueOnly"
+      },
+      "inputArguments": {
+        "$ref": "#/definitions/ValueOnly"
+      },
+      "timestamp": {
+        "type": "string",
+        "pattern": "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)(Z|\\+00:00|-00:00)$"
+      },
+      "additionalProperties": false
+    },
+    "OperationResultValueOnly": {
+      "executionState": {
+        "type": "string",
+        "enum": ["Initiated", "Running", "Completed", "Canceled", "string",
+                 "Failed", "Timeout"]
+      },
+      "inoutputArguments": {
+        "$ref": "#/definitions/ValueOnly"
+      },
+      "outputArguments": {
+        "$ref": "#/definitions/ValueOnly"
+      },
+      "additionalProperties": false
+    },
+    "PropertyValue": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/StringValue"
+        },
+        {
+          "$ref": "#/definitions/NumberValue"
+        },
+        {
+          "$ref": "#/definitions/BooleanValue"
+        }
+      ]
+    },
+    "RangeValue": {
+      "type": "object",
+      "properties": {
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ],
+      "additionalProperties": false
+    },
+    "ReferenceElementValue": {
+      "$ref": "#/definitions/ReferenceValue"
+    },
+    "ReferenceValue": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ModelReference", "ExternalReference"]
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Key"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "RelationshipElementValue": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "$ref": "#/definitions/ReferenceValue"
+        },
+        "second": {
+          "$ref": "#/definitions/ReferenceValue"
+        }
+      },
+      "required": [
+        "first",
+        "second"
+      ],
+      "additionalProperties": false
+    },
+    "SpecificAssetIdValue": {
+      "type": "object",
+      "patternProperties": {
+        "(.*?)": {
+          "type": "string"
+        }
+      }
+    },
+    "StringValue": {
+      "type": "string",
+      "additionalProperties": false
+    },
+    "SubmodelElementCollectionValue": {
+      "$ref": "#/definitions/ValueOnly"
+    },
+    "SubmodelElementListValue": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/SubmodelElementValue"
+      }
+    },
+    "SubmodelElementValue": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/BasicEventElementValue"
+        },
+        {
+          "$ref": "#/definitions/RangeValue"
+        },
+        {
+          "$ref": "#/definitions/MultiLanguagePropertyValue"
+        },
+        {
+          "$ref": "#/definitions/FileBlobValue"
+        },
+        {
+          "$ref": "#/definitions/ReferenceElementValue"
+        },
+        {
+          "$ref": "#/definitions/RelationshipElementValue"
+        },
+        {
+          "$ref": "#/definitions/AnnotatedRelationshipElementValue"
+        },
+        {
+          "$ref": "#/definitions/EntityValue"
+        },
+        {
+          "$ref": "#/definitions/PropertyValue"
+        },
+        {
+          "$ref": "#/definitions/SubmodelElementListValue"
+        }
+      ]
+    },
+    "ValueOnly": {
+      "propertyNames": {
+        "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"
+      },
+      "patternProperties": {
+        "^[A-Za-z_][A-Za-z0-9_-]*$": {
+          "$ref": "#/definitions/SubmodelElementValue"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+----

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_idShortPath.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_idShortPath.adoc
@@ -1,0 +1,52 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
+
+=== Format "Path" (IdShortPath Serialization) in JSON
+
+To get only the idShort paths of a submodel element hierarchy, the serialization format is specified in terms of an idShortPath notation to be returned in an unnamed JSON-array. The notation differs depending on whether a SubmodelElementCollection or a SubmodelElementList is used. In the first case, the submodel element’s idShort is separated by “.” (dot) from top level down to child level. In the second case, square brackets with an index “[\<<index>>]” are appended after the idShort of the containing SubmodelElementList.
+
+In the following example, where a request for idShort paths starts at _MySubmodelElementCollection_ with SerializationModifier level = deep, the list of idShort paths is returned as follows:
+
+Submodel: MySubmodel
+
+* Property: MyTopLevelProperty
+* SMC: MySubmodelElementCollection
+** Property: MySubProperty1
+** Property: MySubProperty2
+** SMC: MySubSubmodelElementCollection
+*** Property: MySubSubProperty1
+*** Property: MySubSubProperty2
+** SML: MySubSubmodelElementList1
+*** Property: “MySubTestValue1”,
+*** Property: “MySubTestValue2”,
+** SML: MySubSubmodelElementList2
+*** SML
+**** Property: “MySubTestValue3”
+
+
+[source,json,linenums]
+----
+[
+  "MySubmodelElementCollection",
+  "MySubmodelElementCollection.MySubProperty1",
+  "MySubmodelElementCollection.MySubProperty2",
+  "MySubmodelElementCollection.MySubmodelElementCollection",
+  "MySubmodelElementCollection.MySubmodelElementCollection.MySubProperty1",
+  "MySubmodelElementCollection.MySubmodelElementCollection.MySubProperty2",
+  "MySubmodelElementCollection.MySubSubmodelElementList1",
+  "MySubmodelElementCollection.MySubSubmodelElementList1[0]",
+  "MySubmodelElementCollection.MySubSubmodelElementList1[1]",
+  "MySubmodelElementCollection.MySubSubmodelElementList2",
+  "MySubmodelElementCollection.MySubSubmodelElementList2[0]",
+  "MySubmodelElementCollection.MySubSubmodelElementList2[0][0]"
+]
+----


### PR DESCRIPTION
Clause 11.4 (ValueOnly + idShortPath) + 
Clause 12.5 (Metadata Objects) from Part 2 moved to Part 1
+ new chapter for Format "Reference" Restructuring 
so that new Clauses fit in
+ added file meta information

closes #325