### PR TITLE
Update antora.yml

### DIFF
--- a/documentation/IDTA-01001/antora.yml
+++ b/documentation/IDTA-01001/antora.yml
@@ -1,5 +1,5 @@
 name: IDTA-01001
-title: DRAFT Part 1: Metamodel
+title: 'DRAFT Part 1: Metamodel'
 version: 'snapshot'
 start_page: ROOT:index.adoc
 nav:


### PR DESCRIPTION
We need to add " around the title. Because the title includes a semi colon: the yaml file thinks it's another entry while it is part of the title, and the website fails to build because of falsely formatted yml file.