### PR TITLE
Rework Chapter "Value-Only serialization" + editorial changes

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/Annex/IDTA-01001_ValueOnlySerializationExample.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Annex/IDTA-01001_ValueOnlySerializationExample.adoc
@@ -132,7 +132,7 @@ As mentioned in Clause 11.4.3, __SubmodelElementCollection__s cannot be validate
         }
       ]
     },
-    "annotation": [
+    "annotations": [
       {
         "AppliedRule": "TechnicalCurrentFlowDirection"
       }

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ChangeLog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ChangeLog.adoc
@@ -46,7 +46,6 @@ Major Changes:
 
 
 * New value "Role" to enumeration AssetKind (https://github.com/admin-shell-io/aas-specs/issues/294[#294])
-
 * Change PathType: support complete URI scheme for files RFC2396 conformant to anyURI of XML Schema 1.0, Part 2 (https://github.com/admin-shell-io/aas-specs/issues/299[#299])
 * Data type  Identifier: change length from 2000 to 2024 characters (https://github.com/admin-shell-io/aas-specs/issues/306[#306])
 * Referable/idShort and Constraint AASd-002: now also allows hyphens to be included in name (https://github.com/admin-shell-io/aas-specs/issues/295[#295])
@@ -75,7 +74,8 @@ also abbreviations partly adopted; changes:
 (https://github.com/admin-shell-io/aas-specs/issues/350[#350])
 	** introduce equivalent matching and rename exact matching to value matching
 	** added notes 
-* improve ValueOnly documentation for elements other than Submodel (https://github.com/admin-shell-io/aas-specs/issues/371[#371], https://github.com/admin-shell-io/aas-specs/issues/370[#370])
+* transfer of chapters on formats Metadata, Paths and Value-Only from Part 2 API to Part 1 Metamodel (https://github.com/admin-shell-io/aas-specs/issues/325[#325])
+* introduce grammar for Value-Only serialization and enhance documentation (https://github.com/admin-shell-io/aas-specs/issues/371[#371], https://github.com/admin-shell-io/aas-specs/issues/370[#370])
 * Transfer from .docx to asciidoc (.adoc) and maintenance in github
 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ChangeLog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ChangeLog.adoc
@@ -75,6 +75,7 @@ also abbreviations partly adopted; changes:
 (https://github.com/admin-shell-io/aas-specs/issues/350[#350])
 	** introduce equivalent matching and rename exact matching to value matching
 	** added notes 
+* improve ValueOnly documentation for elements other than Submodel (https://github.com/admin-shell-io/aas-specs/issues/371[#371], https://github.com/admin-shell-io/aas-specs/issues/370[#370])
 * Transfer from .docx to asciidoc (.adoc) and maintenance in github
 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Common.adoc
@@ -111,7 +111,7 @@ Note 3: usage of the template ID is not restricted to submodel instances. The cr
 
 
 |xref:Identifier[Identifier] |0..1
-|=
+|===
 
 == Has Data Specification Attributes
 
@@ -120,7 +120,7 @@ image::image15.png[]
 
 [.table-with-appendix-table]
 [cols="25%,40%,25%,10%"]
-|=
+|===
 h|Class: 3+e|[[HasDataSpecification]]HasDataSpecification \<<abstract>>
 h|Explanation: 3+a|Element that can be extended by using data specification templates. A data specification template defines a named set of additional attributes an element may or shall have. The data specifications used are explicitly specified with their global ID.
 h|Inherits from: 3+|--
@@ -177,13 +177,13 @@ h|Explanation h|Type h|Card.
 
 .2+e|extension 3+| `\https://admin-shell.io/aas/3/1/HasExtensions/extensions`  
 a|An extension of the element. |xref:Extension[Extension] |0..*
-|=
+|===
 
 {empty} +
 
 [.table-with-appendix-table]
 [cols="25%,40%,25%,10%"]
-|=
+|===
 h|Class: 3+e|[[Extension]]Extension
 h|Explanation: 3+|Single extension of an element
 h|Inherits from: 3+|xref:HasSemantics[HasSemantics]
@@ -240,13 +240,13 @@ a| Kind of the element: either template or instance
 Default Value = _Instance_
 
 |xref:ModellingKind[ModellingKind]|0..1
-|=
+|===
 
 The kind enumeration is used to denote whether an element is of kind _Template_ or _Instance_. It is used to distinguish between submodels and submodel templates.
 
 [.table-with-appendix-table]
 [cols="30%h,70%"]
-|=
+|===
 h|Enumeration: e|[[ModellingKind]]ModellingKind
 h|Explanation: |Enumeration for denoting whether an element is a template or an instance
 |Set of: |--
@@ -260,7 +260,7 @@ a|specification of the common features of a structured element in sufficient det
 
 .2+e|Instance | `\https://admin-shell.io/aas/3/0/ModellingKind/Instance` 
 a|concrete, clearly identifiable element instance. Its creation and validation may be guided by a corresponding element template
-|=
+|===
 
 == Has Semantics Attributes
 
@@ -271,7 +271,7 @@ For matching algorithm, see Clause 4.4.1.
 
 [.table-with-appendix-table]
 [cols="25%,40%,25%,10%"]
-|=
+|===
 h|Class: 3+e|[[HasSemantics]]HasSemantics \<<abstract>>
 h|Explanation: 3+a|
 Element that can have a semantic definition plus some supplemental semantic definitions
@@ -357,7 +357,7 @@ Note: some of the administrative information like the version number might need 
 
 .2+e|id 3+| `\https://admin-shell.io/aas/3/1/Identifiable/id`  
 a|The globally unique identification of the element |xref:Identifier[Identifier] |1
-|=
+|===
 
 == Qualifiable Attributes
 
@@ -366,7 +366,7 @@ image::image20.png[]
 
 [.table-with-appendix-table]
 [cols="25%,40%,25%,10%"]
-|=
+|===
 h|Class: 3+e|[[Qualifiable]]Qualifiable \<<abstract>>
 h|Explanation: 3+a|
 A qualifiable element may be further qualified by one or more qualifiers.
@@ -447,13 +447,13 @@ Note: it is recommended to use an external reference.
 
 
 |xref:Reference[Reference] |0..1
-|=
+|===
 
 It is recommended to add a _semanticId_ for the concept of the _Qualifier_. _Qualifier/type_ is the preferred name of the concept of the qualifier or its short name.
 
 [.table-with-appendix-table]
 [cols="30%h,70%"]
-|=
+|===
 |Enumeration: e|[[QualifierKind]]QualifierKind
 h|Explanation: a|Enumeration for kinds of qualifiers
 |Set of: |--

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_ConceptDescriptions.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_ConceptDescriptions.adoc
@@ -27,7 +27,7 @@ The semantics of a property or other elements that may have a semantic descripti
 The description of the concept should follow a standardized schema (realized as data specification template).
 
 
-h|Inherits from: 3+|xref:Identifiable[Identifiable]; xref:HasDataSpecification[HasDataSpecification]
+h|Inherits from: 3+|xref:Spec/IDTA-01001_Metamodel_Common.adoc#Identifiable[Identifiable]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#HasDataSpecification[HasDataSpecification]
 h|ID: 3+| `\https://admin-shell.io/aas/3/1/ConceptDescription`
 
 .2+h|Attribute 3+h| ID
@@ -49,7 +49,7 @@ Note: compare with is-case-of relationship in ISO 13584-32 & IEC EN 61360
 ====
 
 
-|xref:Reference[Reference] |0..*
+|xref:Spec/IDTA-01001_Metamodel_Referencing.adoc#Reference[Reference] |0..*
 |===
 
 Different types of submodel elements require different attributes to describe their semantics. This is why a concept description has at least one data specification template associated with it. This template defines the attributes needed to describe the semantics.

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -26,9 +26,9 @@ In contrast, a class invariant is a constraint that must be true for all instanc
 {aasd117}
 
 
-=
+====
 Note: in other words (AASd-117), __idShort__ is mandatory for all __Referable__s except for referables being direct childs of __SubmodelElementList__s and for all __Identifiable__s.
-=
+====
 
 
 {aasd120}
@@ -36,9 +36,9 @@ Note: in other words (AASd-117), __idShort__ is mandatory for all __Referable__s
 {aasd022}
 
 
-=
+====
 Note: AASd-022 also means that __idShort__s of referables shall be matched sensitive to the case.
-=
+====
 
 
 == Constraints for Qualifiers
@@ -58,13 +58,13 @@ Note: AASd-022 also means that __idShort__s of referables shall be matched sensi
 {aasd116}
 
 
-=
+====
 Note: AASd-116 is important to enable a generic search across global and specific asset IDs.
-=
+====
 
-=
+====
 Note: The semanticId of a SpecificAssetId with the predefined name "gloablAssetId" corresponds to the metamodel attribute "https://admin-shell-io/aas/3/1/AssetInformation/globalAssetId"
-=
+====
 
 == Constraints for Types
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Core.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Core.adoc
@@ -22,17 +22,17 @@ The _derivedFrom_ attribute is used to establish a relationship between two Asse
 |===
 h|Class: 3+e|[[AssetAdministrationShell]]AssetAdministrationShell
 h|Explanation: 3+a|An Asset Administration Shell
-h|Inherits from: 3+|xref:Identifiable[Identifiable]; xref:HasDataSpecification[HasDataSpecification]
+h|Inherits from: 3+|xref:Spec/IDTA-01001_Metamodel_Common.adoc#Identifiable[Identifiable]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#HasDataSpecification[HasDataSpecification]
 h|ID: 3+| `\https://admin-shell.io/aas/3/1/AssetAdministrationShell`  
 
 .2+h|Attribute 3+h| ID
 h|Explanation h|Type h|Card.
 
 .2+e|derivedFrom 3+| `\https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom`
-a|The reference to the Asset Administration Shell, which the Asset Administration Shell was derived from |ModelReference<xref:AssetAdministrationShell[AssetAdministrationShell]> |0..1
+a|The reference to the Asset Administration Shell, which the Asset Administration Shell was derived from |ModelReference<xref:Spec/IDTA-01001_Metamodel_Common.adoc#AssetAdministrationShell[AssetAdministrationShell]> |0..1
 
 .2+e|assetInformation 3+| `\https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation`
-a|Meta information about the asset the Asset Administration Shell is representing |xref:AssetInformation[AssetInformation] |1
+a|Meta information about the asset the Asset Administration Shell is representing |xref:Spec/IDTA-01001_Metamodel_Common.adoc#AssetInformation[AssetInformation] |1
 
 .2+e|submodel 3+| `\https://admin-shell.io/aas/3/1/AssetAdministrationShell/submodels`
 a|
@@ -182,7 +182,7 @@ A specific asset ID describes a generic supplementary identifying attribute of t
 {aasd133}
 
 
-h|Inherits from: 3+|xref:HasSemantics[HasSemantics]
+h|Inherits from: 3+|xref:Spec/IDTA-01001_Metamodel_Common.adoc#HasSemantics[HasSemantics]
 h|ID: 3+| `\https://admin-shell.io/aas/3/1/SpecificAssetId`  
 
 .2+h|Attribute 3+h| ID
@@ -246,7 +246,7 @@ A submodel defines a specific aspect of the asset represented by the Asset Admin
 A submodel is used to structure the digital representation and technical functionality of an Administration Shell into distinguishable parts. Each submodel refers to a well-defined domain or subject matter. Submodels can become standardized and, in turn, submodel templates.
 
 
-h|Inherits from: 3+|xref:Identifiable[Identifiable]; xref:HasKind[HasKind]; xref:HasSemantics[HasSemantics]; xref:Qualifiable[Qualifiable]; xref:HasDataSpecification[HasDataSpecification]
+h|Inherits from: 3+|xref:Spec/IDTA-01001_Metamodel_Common.adoc#Identifiable[Identifiable]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#HasKind[HasKind]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#HasSemantics[HasSemantics]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#Qualifiable[Qualifiable]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#HasDataSpecification[HasDataSpecification]
 h|ID: 3+| `\https://admin-shell.io/aas/3/1/Submodel`  
 
 .2+h|Attribute 3+h| ID
@@ -272,7 +272,7 @@ Submodel elements may also have defined data specification templates. A template
 |===
 h|Class: 3+e|[[SubmodelElement]]SubmodelElement \<<abstract>>
 h|Explanation: 3+a|A submodel element is an element suitable for the description and differentiation of assets.
-h|Inherits from: 3+|xref:Referable[Referable]; xref:HasSemantics[HasSemantics]; xref:Qualifiable[Qualifiable]; xref:HasDataSpecification[HasDataSpecification]
+h|Inherits from: 3+|xref:Spec/IDTA-01001_Metamodel_Common.adoc#Referable[Referable]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#HasSemantics[HasSemantics]; xref:Spec/IDTA-01001_Metamodel_Common.adoc#Qualifiable[Qualifiable]; xref:HasDataSpecification[HasDataSpecification]
 h|ID: 3+| `\https://admin-shell.io/aas/3/1/SubmodelElement`  
 
 .2+h|Attribute 3+h| ID

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_DataTypes.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_DataTypes.adoc
@@ -136,6 +136,15 @@ Note 2: a langString is a string value tagged with a language code.
 
 Realization depends on the serialization rules for a technology.
 
+The language code is as defined for values of type langString, i.e.
+in accordance with IETF https://tools.ietf.org/html/rfc5646#page-5[RFC 5646], 
+the language names match the following regular expression:
+
+[listing]
+....
+		^[a-z]\{2,4}(-[A-Z][a-z]\{3})?(-([A-Z]\{2}|[0-9]\{3}))?$
+....	
+
 a|
 In xml:
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Environment.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Environment.adoc
@@ -28,18 +28,18 @@ Note: _Environment_ is not an identifiable or referable element. It is introduce
 |===
 h|Class: 3+e|[[Environment]]Environment
 h|Explanation: 3+a|Container for the sets of different identifiables
-h|Inherits from: 3+|xref:Reference[Reference]
+h|Inherits from: 3+|xref:Spec/IDTA-01001_Metamodel_Referencing.adoc#Reference[Reference]
 h|ID: 3+| `\https://admin-shell.io/aas/3/1/Environment`
 
 .2+h|Attribute 3+h| ID
 h|Explanation h|Type h|Card.
 
 .2+e|assetAdministrationShell 3+| `\https://admin-shell.io/aas/3/1/Environment/assetAdministrationShells`
-a|Asset Administration Shell |xref:AssetAdministrationShell[AssetAdministrationShell] |0..*
+a|Asset Administration Shell |xref:Spec/IDTA-01001_Metamodel_Core.adoc#AssetAdministrationShell[AssetAdministrationShell] |0..*
 
 .2+e|submodel 3+| `\https://admin-shell.io/aas/3/1/Environment/submodels`
-a|Submodel |xref:Submodel[Submodel] |0..*
+a|Submodel |xref:Spec/IDTA-01001_Metamodel_Core.adoc#Submodel[Submodel] |0..*
 
 .2+e|conceptDescription 3+| `\https://admin-shell.io/aas/3/1/Environment/conceptDescriptions`
-a|Concept description |xref:ConceptDescription[ConceptDescription] |0..*
+a|Concept description |xref:Spec/IDTA-01001_Metamodel_ConceptDescriptions.adoc#ConceptDescription[ConceptDescription] |0..*
 |===

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_SubmodelElements.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_SubmodelElements.adoc
@@ -763,7 +763,7 @@ The numbering starts with Zero (0).
 {aasd109}
 
 
-h|Inherits from: 3+|xref:SubmodelElement[SubmodelElement]
+h|Inherits from: 3+|xref:Spec/IDTA-01001_Metamodel_Core.adoc#:SubmodelElement[SubmodelElement]
 h|ID: 3+| `\https://admin-shell.io/aas/3/0/SubmodelElementList`
 
 .2+h|Attribute 3+h| ID
@@ -778,7 +778,7 @@ Default: True
 |boolean |0..1
 
 .2+e|value 3+| `\https://admin-shell.io/aas/3/0/SubmodelElementList/values`
-a|Submodel element contained in the list |xref:SubmodelElement[SubmodelElement] |0..*
+a|Submodel element contained in the list |xref:Spec/IDTA-01001_Metamodel_Core.adoc#:SubmodelElement[SubmodelElement] |0..*
 
 .2+e|semanticIdListElement 3+| `\https://admin-shell.io/aas/3/0/SubmodelElementList/semanticIdListElement`
 a|
@@ -790,11 +790,11 @@ Note: it is recommended to use an external reference.
 ====
 
 
-|xref:Reference[Reference] |0..1
+|xref:Spec/IDTA-01001_Metamodel_Referencing.adoc#:Reference[Reference] |0..1
 
 .2+e|typeValueListElement  3+| `\https://admin-shell.io/aas/3/0/SubmodelElementList/typeValueListElement/typeValueListElement`
-a|The submodel element type of the submodel elements contained in the list |xref:AasSubmodelElements[AasSubmodelElements]|1
+a|The submodel element type of the submodel elements contained in the list |xref:Spec/IDTA-01001_Metamodel_DataTypes.adoc#:AasSubmodelElements[AasSubmodelElements]|1
 
 .2+e|valueTypeListElement 3+| `\https://admin-shell.io/aas/3/0/SubmodelElementList/valueTypeListElement`
-a|The value type of the submodel element contained in the list |xref:DataTypeDefXsd[DataTypeDefXsd]|0..1
+a|The value type of the submodel element contained in the list |xref:Spec/IDTA-01001_Metamodel_DataTypes.adoc#:DataTypeDefXsd[DataTypeDefXsd]|0..1
 |===

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_SubmodelElements.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_SubmodelElements.adoc
@@ -424,12 +424,12 @@ A media type (also MIME type and content type) is a two-part identifier for file
 The Internet Assigned Numbers Authority (IANA) is the official authority for the standardization and publication of these classifications.
 
 
-=
+====
 Note: for information on handling supplementary external files in exchanging Asset Administration Shells in AASX package format see also 
-[Part 5 of the series "Specification of the Asset Administration Shell"](https://industrialdigitaltwin.org/en/content-hub/aasspecifications). 
+Part 5 of the series link:https://industrialdigitaltwin.org/en/content-hub/aasspecifications["Specification of the Asset Administration Shell"]. 
 An absolute path is used in case the file exists independently of the Asset Administration Shell.
 A relative path, relative to the package root, should be used if the file is part of a serialized package of the Asset Administration Shell.
-=
+====
 
 
 [.table-with-appendix-table]
@@ -486,9 +486,9 @@ a|
 Reference to the global unique ID of a coded value.
 
 
-=
+====
 Note: it is recommended to use an external reference.
-=
+====
 
 
 |xref:Reference[Reference] |0..1
@@ -591,9 +591,9 @@ a|The value of the property instance |xref:ValueDataType[ValueDataType] |0..1
 a| Reference to the global unique ID of a coded value
 
 
-=
+====
 Note: it is recommended to use an external reference.
-=
+====
 
 
 |xref:Reference[Reference] |0..1
@@ -690,17 +690,17 @@ image::image44.png[]
 Submodel Element Collections are used for complex elements with a typically fixed set of properties with unique names. This set of properties is typically predefined by the semantic definition (referenced via _semanticId_) of the submodel element collection. Each property within the collection itself should have clearly defined semantics.
 
 
-=
+====
 Note: the different elements of a submodel element collection do not have to have different __semanticId__s. However, in these cases the usage of a _SubmodelElementList_ should be considered.
-=
+====
 
 
 Example: a single document has a predefined set of properties like title, version, author, etc. They logically belong to a document. So a single document is represented by a _SubmodelElementCollection_. An asset usually has many different documents available like operating instructions, safety instructions, etc. The set of all documents is represented by a _SubmodelElementList_ (see Clause _5.3.7.17)_. In this case, we have a _SubmodelElementList_ of __SubmodelElementCollection__s.
 
 
-=
+====
 Note: the elements within a submodel element collection are not ordered. Every element has a unique ID (its "idShort"). However, it is recommended to adhere to the order defined in the submodel template.
-=
+====
 
 
 [.table-with-appendix-table]
@@ -726,9 +726,9 @@ image::image45.png[]
 Submodel element lists are used for sets (i.e. unordered collections without duplicates), ordered lists (i.e. ordered collections that may contain duplicates), bags (i.e. unordered collections that may contain duplicates), and ordered sets (i.e. ordered collections without duplicates).
 
 
-=
+====
 Note: there is no _idShort_ for submodel elements in lists (see Constraint AASd-120).
-=
+====
 
 
 Submodel element lists are also used to create multi-dimensional arrays. A two-dimensional array listlink:#bib3[[3\]]link:#bib5[[5\]] with _Property_ values would be realized like follows: the first submodel element list would contain three _SubmodelElementList_ elements. Each of these three _SubmodelElementLists_ would contain 5 single _Property_ elements. The _semanticId_ of the contained properties would be the same for all lists in the first list, i.e. _semanticIdListElement_ would be identical for all three lists contained in the first list. The _semanticId_ of the three contained lists would differ depending on the dimension it represents. In case of complex values in the array, a _SubmodelElementCollection_ would be used as values in the leaf lists.
@@ -745,9 +745,9 @@ h|Explanation: 3+a|
 A submodel element list is an ordered list of submodel elements.
 
 
-=
+====
 Note: the list is ordered although the ordering might not be relevant (see attribute "orderRelevant".)
-=
+====
 
 
 The numbering starts with Zero (0).
@@ -785,9 +785,9 @@ a|
 Semantic ID which the submodel elements contained in the list match
 
 
-=
+====
 Note: it is recommended to use an external reference.
-=
+====
 
 
 |xref:Reference[Reference] |0..1

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_SubmodelElements.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_SubmodelElements.adoc
@@ -793,7 +793,7 @@ Note: it is recommended to use an external reference.
 |xref:Spec/IDTA-01001_Metamodel_Referencing.adoc#:Reference[Reference] |0..1
 
 .2+e|typeValueListElement  3+| `\https://admin-shell.io/aas/3/0/SubmodelElementList/typeValueListElement/typeValueListElement`
-a|The submodel element type of the submodel elements contained in the list |xref:Spec/IDTA-01001_Metamodel_DataTypes.adoc#:AasSubmodelElements[AasSubmodelElements]|1
+a|The submodel element type of the submodel elements contained in the list |xref:Spec/IDTA-01001_Metamodel_Referencing.adoc#:AasSubmodelElements[AasSubmodelElements]|1
 
 .2+e|valueTypeListElement 3+| `\https://admin-shell.io/aas/3/0/SubmodelElementList/valueTypeListElement`
 a|The value type of the submodel element contained in the list |xref:Spec/IDTA-01001_Metamodel_DataTypes.adoc#:DataTypeDefXsd[DataTypeDefXsd]|0..1

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_MetaDataObjects.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_MetaDataObjects.adoc
@@ -14,10 +14,11 @@ Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, d
 === Format "Metadata" (Metadata-Serialization)
 
 
-Metadata objects are defined for scenarios where a client only wants to access the metadata of an object, but not the value. *Metadata objects are only part of HTTP/REST and do not change the metamodel.* Metadata objects are used to reduce the payload response to a minimum and to avoid the recursive traversing through the data model when not needed. In many cases, a client is not interested in each child element or value of a resource, but only in the resource itself.
+Metadata objects are defined for scenarios where a client only wants to access the metadata of an object, but not the value. Metadata objects are used to reduce the payload response to a minimum and to avoid the recursive traversing through the data model when not needed. In many cases, a client is not interested in each child element or value of a resource, but only in the resource itself.
 
 A metadata object does not contain any additional fields in relation to its full object representation, only some fields are left off. The left off fields are fields which could be requested by an own API call and may consist of a recursive or potentially large substructure. The serialization of a metadata object is the same as for the original full object, but without the left off fields.
 
+[#table:meta-data-attributes]
 .Metadata Attributes
 [%autowidth, width="100%", cols="48%,52%",options="header",]
 |===

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -425,7 +425,7 @@ For a _MultiLanguageProperty_ the Value-Only payload is minimized to the followi
 [
     {"de": "Das ist ein deutscher Bezeichner"},
     {"en": "That's an English label"}
-  ]
+]
 
 ----
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -79,6 +79,10 @@ There is no Value-Only serialization for an Operation. However, a Value-Only ser
 |RelationshipElement a|first, second
 |AnnotatedRelationshipElement a|first, second, annotations
 
+====
+The Value-Only serialization of the annotations is created the same way as the Value-Only serialization of a SubmodelElementCollection.
+====
+
 2+|*DataElements*
 |Property a| (value)
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -11,55 +11,221 @@ Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, d
 ////
 
 
-=== Format "Value" (ValueOnly-Serialization) in JSON
+=== Format "Value" (Value-Only Serialization) in JSON
 
 
-In many cases, applications using data from Asset Administration Shells already know the Submodel regarding its structure, attributes, and semantics. Consequently, there is not always a need to receive the entire model information, which can be requested separately via _Content_ modifier set to _Metadata_, in each request since it is constant most of the time. Instead, applications are most likely only interested in the values of the modelled data. Furthermore, having limited processing power or limited bandwidth, one use case of this SerializationModifier is to transfer data as efficiently as possible. Semantics and data might be split into two separate architecture building blocks. For example, a database would suit the needs for querying semantics, while a device would only provide the data at runtime. Two separate requests make it possible to build up a user interface (UI) and show new upcoming values highly efficiently.
+In many cases, applications using data from Asset Administration Shells already know the Submodel regarding its structure, attributes, and semantics, for example via the used Submodel Template. Consequently, there is not always a need to receive the entire model information. Instead, applications are most likely only interested in the values of the modelled data. Furthermore, having limited processing power or limited bandwidth, one use case of the Format "Value" is to transfer data as efficiently as possible. Semantics and data might be split into two separate architecture building blocks. For example, a database would suit the needs for querying semantics, while a device would only provide the data at runtime. Two separate requests make it possible to build up a user interface (UI) and show new upcoming values highly efficiently.
 
 Values are only available for
 
 * All subtypes of abstract type _DataElement_,
-* SubmodelElementList and SubmodelElementCollection resp. for their included SubmodelElements,
+* SubmodelElementList and SubmodelElementCollection, resp. and for their included SubmodelElements,
 * ReferenceElement,
 * RelationshipElement + AnnotatedRelationshipElement,
 * Entity,
 * BasicEventElement,
 * Submodel.
 
-Capabilities are excluded from the SerializationModifier’s scope since only data containing elements are in the focus. They are consequently omitted in the serialization.
+Capabilities are excluded from the Value-Only serialization scope since only data containing elements are in the focus. They are consequently omitted in the serialization.
 
-The following rules shall be adhered to when serializing a submodel with the SerializationModifier _Value_:
+The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#table:meta-data-attributes[Metadata Attributes]). So it is quite the other way around:
 
-* A submodel is serialized as an unnamed JSON object.
-* A submodel element is considered a leaf submodel element if it does not contain other submodel elements. A leaf submodel element follows the rules for the different submodel elements considered in the serialization, as described below. If it is not a leaf element, the serialization rules must be transitively followed until the value is a leaf submodel element.
-* For each submodel element:
-** _Property_ is serialized as $\{Property/idShort}: $\{Property/value} where $\{Property/value} is the JSON serialization of the respective property’s value in accordance with the data type to value mapping (see table after this section).
-** _MultiLanguageProperty_ is serialized as named JSON object with $\{MultiLanguageProperty/idShort} as the name of the containing JSON property. The JSON object contains an array of JSON objects for each language of the _MultiLanguageProperty_ with the language as name and the corresponding localized string as value of the respective JSON property. The language name is defined as two chars according to ISO 639-1.
-** _Range_ is serialized as named JSON object with $\{Range/idShort} as the name of the containing JSON property. The JSON object contains two JSON properties. The first is named “min”. The second is named “max”. Their corresponding values are $\{Range/min} and $\{Range/max}.
-** _File_ and _Blob_ are serialized as named JSON objects with $\{File/idShort} or $\{Blob/idShort}as the name of the containing JSON property. The JSON object contains two JSON properties. The first refers to the content type named $\{File/contentType} resp. $\{Blob/contentType}. The latter refers to the value named “value” $\{File/value} resp. $\{Blob/value}. The resulting ValueOnly object is indistinguishable whether it contains File or Blob attributes. Therefore, the receiver needs to take the type of the target resource into account. Since the receiver knows in advance if a File or a Blob SubmodelElement shall be manipulated, it can parse the transferred ValueOnly object accordingly as a File or Blob object.
-** _SubmodelElementCollection_ is serialized as named JSON object with $\{SubmodelElementCollection/idShort} as the name of the containing JSON property. The elements contained within the struct are serialized according to their respective type with $\{SubmodelElement/idShort} as the name of the containing JSON property.
-** _SubmodelElementList_ is serialized as a named JSON array with $\{SubmodelElementList/idShort} as the name of the containing JSON property. The elements in the JSON array are the ValueOnly serializations of the elements contained in the SubmodelElementList while preserving the order, i.e. index n in the JSON array is the ValueOnly serialization of the element at index n of the SubmodelElementList.
-** _ReferenceElement_ is serialized as $\{ReferenceElement/idShort}: $\{ReferenceElement/value} where $\{ReferenceElement/value} is the serialization of the _Reference_ class.
-** _RelationshipElement_ is serialized as named JSON object with $\{RelationshipElement/idShort} as the name of the containing JSON property. The JSON object contains two JSON properties. The first is named “first”. The second is named “second”. Their corresponding values are $\{RelationshipElement/first} resp. $\{Relationship/second}. The values are serialized according to the serialization of a _ReferenceElement_ (see above).
-** _AnnotatedRelationshipElement_ is serialized according to the serialization of a _ReleationshipElement_ (see above). Additionally, a third named JSON object is introduced with “annotations” as the name of the containing JSON property. The value is $\{AnnotatedRelationshipElement/annotations}. The values of the array items are serialized depending on the type of the annotation data element.
-** _Entity_ is serialized as named JSON object with $\{Entity/idShort} as the name of the containing JSON property. The JSON object contains three JSON properties. The first is named “statements” $\{Entity/statements} and contains an array of the serialized submodel elements according to their respective serialization mentioned in this clause. The second is named either “globalAssetId” or “specificAssetId” and contains either a _Reference_ (see above) or a _SpecificAssetId_. The third property is named “entityType” and contains a string representation of $\{Entity/entityType}.
-** _BasicEventElement_ is serialized as named JSON object with $\{BasicEventElement/idShort} as the name of the containing JSON property. The JSON object contains one JSON property named “observed” with the corresponding value of $\{BasicEventElement/observed} as the standard serialization of the _Reference_ class.
-** _SpecificAssetId_ is serialized as named JSON object with three JSON properties named as the attributes of _SpecificAssetId._
+[[table:value-data-attributes]]
+.Metadata Attributes
+[%autowidth, width="100%", cols="48%,52%",options="header",]
+|===
+|*Class Name* |*Fields for Value-Only representationfootnote:[(value) means that the attribute name is not relevant, only its value, 
+for the other attributes the attribute itself will be seen in the payload]*
+2+|*Identifiables*
+|AssetAdministrationShell |assetInformation, submodels
+|Submodel |submodelElements
+2+|*SubmodelElements*
+|SubmodelElementCollection | (value)
+|SubmodelElementList | (value)
+|Entity |statements, globalAssetId, specificAssetId
+|BasicEventElement |observed
+|Capability |--
+|Operation |--
+2+|*DataElements*
+|Property | (value)
+|MultilanguageProperty | (value)
+|Range |min, max
+|ReferenceElement |value
+|RelationshipElement |first, second
+|AnnotatedRelationshipElement |first, second, annotations
+|Blob |value, contentType
+|File |value, contentType
+|===
 
-* Submodel elements defined in the submodel other than the ones mentioned above are not subject to serialization of that SerializationModifier.
-
-
-
-The following rules shall be adhered to when serializing a submodel element different than a submodel with the SerializationModifier _Value_:
-
-* The submodel element is serialized as an unnamed JSON object.
-* A submodel element is considered a leaf submodel element if it does not contain other submodel elements. A leaf submodel element follows the rules for the different submodel elements considered in the serialization, as described for a submodel above. If it is not a leaf element, the serialization rules must be transitively followed until the value is a leaf submodel element.
+Exception:
+Property/valueId and MultiLanguagePropertyId are also no Metadata attributes. However, they are ignored in the Value-Only serialization.
 
 A submodel element is omitted if no value is defined for it for the requesting submodel or submodel element.
 
-*Data type to value mapping* footnote:[cf. https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/2.0.0/datatypes.html]
+==== Grammar Value-Only Serialization
 
-The serialization of submodel element values is described in the following table. The left column “Data Type” shows the data types which can be used for submodel element values. The data types are defined according to the W3C XML Schema (https://www.w3.org/TR/xmlschema-2/#built-in-datatypes and https://www.w3.org/TR/xmlschema-2/#built-in-derived). “Value Range” further explains the possible range of data values for this data type. The right column comprises related examples of the serialization of submodel element values.
+In the following the grammar for Value-Only serialization is defined in a formal way:
+
+[listing]
+....
+
+<value-only-of-Submodel> ::= 
+    <value-only-of-SubmodelElementCollection>
+
+<value-only-of-sme> ::= 
+    <value-only-of-SubmodelElementCollection> | <value-only-of-SubmodelElementList> | 
+    <value-only-of-DataElement> | <value-only-of-RelationshipElement> | 
+    <value-only-of-AnnotatedRelationshipElement> | <value-only-of-Entity> | 
+    <value-only-of-BasicEvent>
+
+<value-only-of-DataElement> ::=  
+    <value-only-of-Property> | <value-only-of-MultiLanguageProperty> | 
+    <value-of-Range> | <value-of-ReferenceElement> |  
+    <value-only-of-File> | <value-only-of-Blob> 
+
+
+<value-only-of-SubmodelElementCollection> ::=
+     '{' 
+        {<jd><idShort-of-sme><jd>':' <jd><value-only-of-sme><jd>','}*  
+         <jd><idShort-of-sme><jd>':' <jd><value-only-of-sme><jd>
+        |
+        ''
+     '}'
+
+<value-only-of-SubmodelElementList> ::= 
+    '[' 
+       {<value-only-of-sme>','}* 
+	    <value-only-of-sme> | 
+       ''
+    ']' 
+    
+<value-only-of-Property> ::= 
+	<value-of-Property> 
+
+<value-only-of-MultiLanguageProperty> ::=
+   '['
+      { '{' <language-tag>':' <value-string> '},' }* 
+        '{' <language-tag>':' <value-string> '}'
+   ']'
+
+<value-only-of-Range> ::=  
+    '{  
+		"min":' <value of Range>',' 
+       '"max":' <value of Range>
+    '}'
+
+<value-of-ReferenceElement> ::= 
+    <value-Reference>
+
+<value-of-File> ::= 
+    '{
+        "Contenttype":' <value-ContentType>','
+       '"value":' <value-PathType>
+    '}'
+
+<value-of-Blob> ::= 
+    '{'
+       '"ContentType":' <value-ContentType>[','
+       '"value":' <value-BlobType> ]
+    '}'
+
+<value-only-of-RelationshipElement> ::= 
+    '{
+        "first":' <value-Reference>','
+       '"second":' <value-Reference> 
+    '}'
+    
+<value-only-of-AnnotatedRelationshipElement> ::=
+    '{
+        "first"': <value-Reference>','
+       '"second"': <value-Reference>[','
+       '"annotations": ['  
+            {<jd><idShort-of-sme><jd>':' <value-only-of-DataElement>','}*  
+             <jd><idShort-of-DataElement><jd>':'  <value-only-of-sme>
+        ']'
+    '}'
+        
+<value-only-of-Entity> ::=
+    '{'
+      ['"statements": ['
+          {<jd><idShort-of-sme><jd>':' <value-only-of-sme>','}*  
+           <jd><idShort-of-sme><jd>':' <value-only-of-sme>
+        '],']
+       '"entityType":' <value-EntityType>[',' (
+       '"globalAssetId":' <value-Identifier>[','
+       '"specificAssetIds":' <value-of-specificAssetIds>','] | 
+       '"specificAssetIds":' <value-of-specificAssetIds> )
+       ]
+    '}'
+    
+<value-only-of-BasicEvent> ::= 
+    '{
+        "observed":' <value-Reference>
+    '}'
+    
+<value-of-Property> ::= 
+	value of attribute Property/value with data type as specified in Property/valueType. 
+	In case of data type "xs:string" delimiters '"' are added (e.g. "this-is-mystring")
+
+<value-of-Range> ::= 
+	value of Range/min or Range/max, resp. 
+	with data type as specified in Range/valueType
+
+<value-Reference> ::= 
+    '{'
+       '"type":' <value-of-Reference-type>','
+       '"keys":' <value-of-Reference-keys>
+    '}'
+
+<idShort-of-sme> ::= 
+	value of SubmodelElement/idShort
+
+<language-tag> ::= 
+	language tag as defined for values of type langString, i.e.
+	in accordance with IETF https://tools.ietf.org/html/rfc5646#page-5[RFC 5646], the language names match the following regular expression:
+
+		^[a-z]\{2,4}(-[A-Z][a-z]\{3})?(-([A-Z]\{2}|[0-9]\{3}))?$
+	
+	e.g. "en" for Englisch
+
+<value-of-Reference-type> ::= 
+	value of Reference/type
+
+<value-of-Reference-keys> ::= 
+	"Normal" JSON serialization of list of elements of type Key
+
+<value-of-specificAssetIds> ::= 
+	"Normal" JSON serialization of list of elements of type SpecificAssetId
+
+<value-string> ::= 
+	value of type string with delimiters '"', e.g. "this is my string"
+
+<value-PathType> ::= 
+	value of type PathType
+
+<value-BlobType> ::= 
+	value of type BlobType
+
+<value-Identifier> ::= 
+	value of type Identifier
+
+<jd> ::= 
+	<json-delimiter>  
+
+<sd> ::= 
+	<string-delimiter>  
+
+<json-delimiter> ::= 
+	'"'
+
+<string-delimiter> ::= 
+	'"'
+....
+
+
+==== Data Type to Value Mapping
+
+The serialization of submodel element values is described in the following tablefootnote:[cf. https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html]. The left column “Data Type” shows the data types which can be used for submodel element values. The data types are defined according to the W3C XML Schema 1.0 (https://www.w3.org/TR/xmlschema-2/#built-in-datatypes and https://www.w3.org/TR/xmlschema-2/#built-in-derived). “Value Range” further explains the possible range of data values for this data type. The right column comprises related examples of the serialization of submodel element values.
 
 .Mapping of Data Types in ValueOnly-Serialization
 [%autowidth, width="100%", cols="15%,15%,9%,30%,31%",options="header",]
@@ -115,7 +281,7 @@ xs:language, xs:normalizedString, xs:token, xs:NMTOKEN, xs:Name, xs:NCName, xs:Q
 
 
 ====
-Note 1: due to the limits in the representation of numbers in JSON, the maximum integer number that can be used without losing precision is 2⁵³-1 (defined as Number.MAX_SAFE_INTEGER). Even if the used data type would allow higher or lower values, they cannot be used if they cannot be represented in JSON. Affected data types are unbounded numeric types xs:decimal, xs:integer, xs:positiveInteger, xs:nonNegativeInteger, xs:negativeInteger, xs:nonPositiveInteger and the bounded type xs:unsignedLong. Other numeric types are not affected. footnote:[cf. https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/v1.0.0/datatypes.html (with adjustments for +/-INF, NaN, and language-typed literal support)]
+Note 1: due to the limits in the representation of numbers in JSON, the maximum integer number that can be used without losing precision is 2⁵³-1 (defined as Number.MAX_SAFE_INTEGER). Even if the used data type would allow higher or lower values, they cannot be used if they cannot be represented in JSON. Affected data types are unbounded numeric types xs:decimal, xs:integer, xs:positiveInteger, xs:nonNegativeInteger, xs:negativeInteger, xs:nonPositiveInteger and the bounded type xs:unsignedLong. Other numeric types are not affected. footnote:[cf. https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html (with adjustments for +/-INF, NaN, and language-typed literal support)]
 ====
 
 
@@ -132,21 +298,78 @@ Note 3: language-tagged strings (rdf:langString) containing single quotes (‘) 
 ====
 
 
-*Examples conformant to link:#bib1[[1\]]:*
+==== Example Value-Only serialization for a Submodel
 
-Full serialization of single submodel element _Property_:
+The following example shows the JSON Value-Only serialization for a Submodel with name "Example" and two direct SubmodelElements "Families" and "MaxRotationSpeed". "Families" is represented by a SubmodelElementList with SubmodelElementCollections as its elements. Each of the SubmodelCollections has two mandatory elements "NameOfMother" and "NameOfFather" and two optional elements "NameOfSon" and "NameOfDaugther". All of these elements have data type "xs:string". "MaxRotationSpeed" is a property with data type "xs:int".
+
+[source,json,linenums]
+----
+{ "Families": 
+   [
+    {
+    "NameOfMother": "Martha ExampleFamily1",
+    "NameOfFather": "Jonathan ExampleFamily1",
+    "NameOfSon": "Clark ExampleFamily1"
+    },
+    {
+    "NameOfMother": "Anna ExampleFamily2",
+    "NameOfFather": "Hugo ExampleFamily2",
+    "NameOfDaughter": "Eve ExampleFamily2"
+    }
+   ],
+  "MaxRotationSpeed": 5000
+}
+----
+
+The JSON Value-Only serialization for the element "Families" within the submodel above looks like this:
+
+[source,json,linenums]
+----
+[
+ {
+    "NameOfMother": "Martha ExampleFamily1",
+    "NameOfFather": "Jonathan ExampleFamily1",
+    "NameOfSon": "Clark ExampleFamily1"
+ },
+ {
+    "NameOfMother": "Anna ExampleFamily2",
+    "NameOfFather": "Hugo ExampleFamily2",
+    "NameOfDaughter": "Eve ExampleFamily2"
+ }
+]
+----
+
+The JSON Value-Only serialization for the  first element within the "Families" list above looks like this:
+
+[source,json,linenums]
+----
+{
+    "NameOfMother": "Martha ExampleFamily1",
+    "NameOfFather": "Jonathan ExampleFamily1",
+    "NameOfSon": "Clark ExampleFamily1"
+}
+----
+
+The JSON Value-Only serialization for the  property "MaxRotationSpeed" of the submodel above looks like this:
+[source,json,linenums]
+----
+5000
+----
+
+
+
+
+The Format "Normal" in comparison to this Value-Only serialization of the property "MaxRotationSpeed" would look like this:
 
 [source,json,linenums]
 ----
 {
   "idShort": "MaxRotationSpeed",
-  "category": "PARAMETER",
-  "kind": "Instance",
-  "semanticlId": {
-    "type": "ModelReference",
+  "semanticId": {
+    "type": "ExternalReference",
     "keys": [
       {
-        "type": "ConceptDescription",
+        "type": "GlobalReference",
         "value": "0173-1#02-BAA120#008"
       }
     ]
@@ -157,64 +380,33 @@ Full serialization of single submodel element _Property_:
 }
 ----
 
-With the SerializationModifier set to _Value,_ the payload within a submodel or structured submodel element is minimized to the following:
+==== Examples Value-Only serialization for all submodel element types 
 
+In the following examples for Value-Only serializations for all submodel element types are given.
+
+
+For a single _Property_ named "MaxRotationSpeed", the value-Only payload is minimized to the following (assuming its value is 5000):
 [source,json,linenums]
 ----
-{
-  "MaxRotationSpeed": 5000
-}
-----
-
-If the property itself is the subject for ValueOnly the serialization is minimized to the following:
-[source,json,linenums]
-----
-{
   5000
-}
 ----
 
 
-For a _SubmodelElementCollection_, the struct is serialized within a submodel or structured submodel element as objects denoted by curly brackets:
+
+For a _SubmodelElementCollection_ named "ExampleFamily", the Value-Only payload is minimized to the following,
+i.e. the name of the SubmodelElementCollection is not part of the Value-Only serialization:
 
 [source,json,linenums]
 ----
 {
-  "NamesOfFamilyMembers": {
     "NameOfMother": "Martha ExampleFamily",
     "NameOfFather": "Jonathan ExampleFamily",
     "NameOfSon": "Clark ExampleFamily"
-  }
 }
 ----
 
-If the _SubmodelElementCollection_ itself is the subject for ValueOnly the serialization is minimized to the following:
 
-[source,json,linenums]
-----
-{
-
-    "NameOfMother": "Martha ExampleFamily",
-    "NameOfFather": "Jonathan ExampleFamily",
-    "NameOfSon": "Clark ExampleFamily"
-
-}
-----
-
-For a _SubmodelElementList,_ the struct is serialized within a submodel or structured submodel element as array denoted by square brackets:
-
-[source,json,linenums]
-----
-{
-  "NamesOfFamilyMembers": [
-    "Martha ExampleFamily",
-    "Jonathan ExampleFamily",
-    "Clark ExampleFamily"
-  ]
-}
-----
-
-If the _SubmodelElementList_ itself is the subject for ValueOnly the serialization is minimized to the following:
+For a _SubmodelElementList_ names "FamilyMembers", the Value-Only payload is minimized to the following (values within a SubmodelElementList do not have idShort values):
 
 [source,json,linenums]
 ----
@@ -227,19 +419,7 @@ If the _SubmodelElementList_ itself is the subject for ValueOnly the serializati
 
 
 
-For a _MultiLanguageProperty_ named “Label”, the payload within a submodel or structured submodel element is minimized to the following:
-
-[source,json,linenums]
-----
-{
-  "Label": [
-    {"de": "Das ist ein deutscher Bezeichner"},
-    {"en": "That's an English label"}
-  ]
-}
-----
-
-If the _MultiLanguageProperty_ itself is the subject for ValueOnly the serialization is minimized to the following:
+For a _MultiLanguageProperty_ the Value-Only payload is minimized to the following:
 [source,json,linenums]
 ----
 [
@@ -250,31 +430,10 @@ If the _MultiLanguageProperty_ itself is the subject for ValueOnly the serializa
 ----
 
 
-====
-Note: in accordance with IETF https://tools.ietf.org/html/rfc5646#page-5[RFC 5646], the language names match the following regular expression:
-====
 
 
-[source]
-----
-^[a-z]\{2,4}(-[A-Z][a-z]\{3})?(-([A-Z]\{2}|[0-9]\{3}))?$
-----
 
-
-For a _Range_ named “TorqueRange”, the payload within a submodel or structured submodel element is minimized to the following:
-
-[source,json,linenums]
-----
-{
-  "TorqueRange": {
-    "min": 3,
-    "max": 15
-  }
-}
-----
-
-If the _Range_ itself is the subject for ValueOnly the serialization is minimized to the following:
-[source,json,linenums]
+For a _Range_ named “TorqueRange”, the Value-Only payload  is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -284,47 +443,8 @@ If the _Range_ itself is the subject for ValueOnly the serialization is minimize
 }
 ----
 
-For a _ReferenceElement_ named “MaxRotationSpeedReference”, the payload within a submodel or structured submodel element is minimized to the following:
+For a _ReferenceElement_ named “MaxRotationSpeedReference”, the Value-Only payload  is minimized to the following:
 
-[source,json,linenums]
-----
-{
-  "MaxRotationSpeedReference": {
-    "type": "ModelReference",
-    "keys": [
-      {
-        "type": "Submodel",
-        "value": "http://customer.com/demo/aas/1/1/1234859590"
-      },
-      {
-        "type": "Property",
-        "value": "MaxRotationSpeed"
-      }
-    ]
-  }
-}
-----
-
-For an _ReferenceElement_ representing an _ExternalReference_ with the same name the payload within a submodel or structured submodel element is minimized to the following:
-
-
-[source,json,linenums]
-----
-{
-  "MaxRotationSpeedReference": {
-    "type": "ExternalReference",
-    "keys": [
-      {
-        "type": "GlobalReference",
-        "value": "0173-1#02-BAA120#008"
-      }
-    ]
-  }
-}
-----
-
-If the _Reference_ itself is the subject for ValueOnly the serialization is minimized to the following:
-[source,json,linenums]
 
 [source,json,linenums]
 ----
@@ -339,20 +459,7 @@ If the _Reference_ itself is the subject for ValueOnly the serialization is mini
 }
 ----
 
-For a _File_ named “Document”, the payload within a submodel or structured submodel element is minimized to the following:
-
-[source,json,linenums]
-----
-{
-  "Document": {
-    "contentType": "application/pdf",
-    "value": "SafetyInstructions.pdf"
-  }
-}
-----
-
-If the _File_ itself is the subject for ValueOnly the serialization is minimized to the following:
-[source,json,linenums]
+For a _File_ named “Document”, the Value-Only payload is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -363,30 +470,20 @@ If the _File_ itself is the subject for ValueOnly the serialization is minimized
 ----
 
 
-For a _Blob_ named “Library”, the payload within a submodel or structured submodel element is minimized to the following if the SerializationModifier _Extent_ is set to *_WithoutBLOBValue_*
+For a _Blob_ named “Library”, there are two possibilities for the Value-Only payload. In case the Blob value - that can be very large - 
+shall not be part of the payload the payload is minimized to the followingfootnote:[ 
+for the API a special JSON query parameter, the SerializationModifier _Extent_, is set to *_WithoutBLOBValue_* for this case]
 
 [source,json,linenums]
 ----
 {
-  "Library": {
     "contentType": "application/octet-stream"
   }
 }
 ----
 
-If the SerializationModifier Extent is set to *_WithBlobValue_*, there is an additional attribute containing the base64-encoded value:
-
-[source,json,linenums]
-----
-{
-  "Library": {
-    "contentType": "application/octet-stream",
-    "value": "VGhpcyBpcyBteSBibG9i"
-  }
-}
-----
- 
-If the _Blob_ itself is the subject for ValueOnly the serialization for Extent set to *_WithBlobValue_  is minimized to the following:
+In the second case the Blob value is part of the payload.footnote:[in this case the JSON query parameter SerializationModifier Extent is set to *_WithBlobValue_*], 
+there is an additional attribute containing the base64-encoded value:
 
 [source,json,linenums]
 ----
@@ -396,43 +493,8 @@ If the _Blob_ itself is the subject for ValueOnly the serialization for Extent s
 }
 ----
 
-For a _RelationshipElement_ named “CurrentFlowsFrom”, the payload within a submodel or structured submodel element is minimized to the following:
+For a _RelationshipElement_ named “CurrentFlowsFrom”, the Value-Only payload is minimized to the following:
 
-[source,json,linenums]
-----
-{
-  "CurrentFlowsFrom": {
-    "first": {
-      "type": "ModelReference",
-      "keys": [
-        {
-          "type": "Submodel",
-          "value": "http://customer.com/demo/aas/1/1/1234859590"
-        },
-        {
-          "type": "Property",
-          "value": "PlusPole"
-        }
-      ]
-    },
-    "second": {
-      "type": "ModelReference",
-      "keys": [
-        {
-          "type": "Submodel",
-          "value": "http://customer.com/demo/aas/1/0/1234859123490"
-        },
-        {
-          "type": "Property",
-          "value": "MinusPole"
-        }
-      ]
-    }
-  }
-}
-----
-
-If the _RelationshipElement_ itself is the subject for ValueOnly the serialization is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -466,48 +528,9 @@ If the _RelationshipElement_ itself is the subject for ValueOnly the serializati
 }
 ----
 
-For an _AnnotatedRelationshipElement_ named “CurrentFlowFrom”, with an annotated _Property_-DataElement “AppliedRule”, the payload within a submodel or structured submodel element is minimized to the following:
+For an _AnnotatedRelationshipElement_ named “CurrentFlowFrom”, with an annotated _Property_-DataElement “AppliedRule”, the Value-Only-payload  is minimized to the following:
 
-[source,json,linenums]
-----
-{
-  "CurrentFlowsFrom": {
-    "first": {
-      "type": "ModelReference",
-      "keys": [
-        {
-          "type": "Submodel",
-          "value": "http://customer.com/demo/aas/1/1/1234859590"
-        },
-        {
-          "type": "Property",
-          "value": "PlusPole"
-        }
-      ]
-    },
-    "second": {
-      "type": "ModelReference",
-      "keys": [
-        {
-          "type": "Submodel",
-          "value": "http://customer.com/demo/aas/1/0/1234859123490"
-        },
-        {
-          "type": "Property",
-          "value": "MinusPole"
-        }
-      ]
-    },
-    "annotation": [
-      {
-        "AppliedRule": "TechnicalCurrentFlowDirection"
-      }
-    ]
-  }
-}
-----
 
-If the _RelationshipElementAnnotation_ itself is the subject for ValueOnly the serialization is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -546,30 +569,8 @@ If the _RelationshipElementAnnotation_ itself is the subject for ValueOnly the s
 }
 ----
 
-For an _Entity_ named “MySubAssetEntity”, the payload within a submodel or structured submodel element is minimized to the following:
+For an _Entity_ named “MySubAssetEntity”, the Value-Only-payload is minimized to the following:
 
-[source,json,linenums]
-----
-{
-  "MySubAssetEntity": {
-    "statements": {
-      "MaxRotationSpeed": 5000
-    },
-    "entityType": "SelfManagedEntity",
-    "globalAssetId": {
-      "type": "ExternalReference",
-      "keys": [
-        {
-          "type": "GlobalReference",
-          "value": "http://customer.com/demo/asset/1/1/MySubAsset"
-        }
-      ]
-    }
-  }
-}
-----
-
-If the _Entity_ itself is the subject for ValueOnly the serialization is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -590,30 +591,9 @@ If the _Entity_ itself is the subject for ValueOnly the serialization is minimiz
 }
 ----
 
-For a BasicEventElement named “MyBasicEvent”, the payload within a submodel or structured submodel element is minimized to the following:
+For a BasicEventElement named “MyBasicEvent”, the Value-Only-payload is minimized to the following:
 
-[source,json,linenums]
-----
-{
-  "MyBasicEvent": {
-    "observed": {
-      "type": "ModelReference",
-      "keys": [
-        {
-          "type": "Submodel",
-          "value": "http://customer.com/demo/aas/1/1/1234859590"
-        },
-        {
-          "type": "Property",
-          "value": "CurrentValue"
-        }
-      ]
-    }
-  }
-}
-----
 
-If the _BasicEventElement_ itself is the subject for ValueOnly the serialization is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -627,14 +607,14 @@ If the _BasicEventElement_ itself is the subject for ValueOnly the serialization
         },
         {
           "type": "Property",
-          "value": "CurrentValue"
+          "value": "MaxRotation"
         }
       ]
     }
 }
 ----
 
-===== JSON-Schema for the ValueOnly-Serialization
+==== JSON-Schema for the ValueOnly-Serialization
 
 The following JSON-Schema represents the validation schema for the ValueOnly-Serialization of submodel elements. This holds true for all submodel elements mentioned in the previous clause except for _SubmodelElementCollections_. Since _SubmodelElementCollections_ are treated as objects containing submodel elements of any kind, the integration into the same validation schema would result in a circular reference or ambiguous results ignoring the actual validation of submodel elements other than _SubmodelElementCollections_. Hence, the same validation schema must be applied for each _SubmodelElementCollection_ within a submodel element hierarchy. In this case, it may be necessary to create a specific JSON-Schema for the individual use case. The _SubmodelElementCollection_ is added to the following schema for completeness and clarity. It is, however, not referenced from the _SubmodelElementValue_-oneOf-Enumeration due to the reasons mentioned above. +
 See Annex B for an example that validates against this schema.

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -86,8 +86,8 @@ In the following the grammar for Value-Only serialization is defined in a formal
 
 <value-only-of-SubmodelElementCollection> ::=
      '{' 
-        {<jd><idShort-of-sme><jd>':' <jd><value-only-of-sme><jd>','}*  
-         <jd><idShort-of-sme><jd>':' <jd><value-only-of-sme><jd>
+        {<jd><idShort-of-sme><jd>':' <value-only-of-sme>','}*  
+         <jd><idShort-of-sme><jd>':' <value-only-of-sme>
         |
         ''
      '}'

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -109,7 +109,7 @@ Note: the examples are written in RDF/Turtle syntax, and only "Hello" and "Hallo
 
 |===
 
-The following types defined by the XSD and RDF specifications are explicitly omitted for serialization:
+The following types defined by the XSD and RDF specifications are explicitly omitted for serialization. This is ensured because they are not part of enumerations xref:IDTA-01001_Metamodel_DataTypes.adoc#[DataTypeDefXsd] and xref:IDTA-01001_Metamodel_DataTypes.adoc#[DataTypeDefRdf]:
 
 xs:language, xs:normalizedString, xs:token, xs:NMTOKEN, xs:Name, xs:NCName, xs:QName, xs:ENTITY, xs:ID, xs:IDREF, xs:NOTATION, xs:IDREFS, xs:ENTITIES, xs:NMTOKENS, rdf:HTML and rdf:XMLLiteral.
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -55,6 +55,7 @@ The following rules shall be adhered to when serializing a submodel element diff
 * The submodel element is serialized as an unnamed JSON object.
 * A submodel element is considered a leaf submodel element if it does not contain other submodel elements. A leaf submodel element follows the rules for the different submodel elements considered in the serialization, as described for a submodel above. If it is not a leaf element, the serialization rules must be transitively followed until the value is a leaf submodel element.
 
+Optional submodel elements are omitted if not specified for the requesting submodel or submodel element.
 
 *Data type to value mapping* footnote:[cf. https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/2.0.0/datatypes.html]
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -125,7 +125,7 @@ In the following the grammar for Value-Only serialization is defined in a formal
 
 <value-of-Blob> ::= 
     '{'
-       '"ContentType":' <value-ContentType>[','
+       '"contentType":' <value-ContentType>[','
        '"value":' <value-BlobType> ]
     '}'
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -242,7 +242,7 @@ For a _MultiLanguageProperty_ named “Label”, the payload within a submodel o
 If the _MultiLanguageProperty_ itself is the subject for ValueOnly the serialization is minimized to the following:
 [source,json,linenums]
 ----
-  [
+[
     {"de": "Das ist ein deutscher Bezeichner"},
     {"en": "That's an English label"}
   ]

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -27,7 +27,7 @@ Values are only available for
 
 Capabilities are excluded from the Value-Only serialization scope since only data containing elements are in the focus. They are consequently omitted in the serialization.
 
-The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#format-metadata-metadata-serialization[Metadata Attributes]). So the serialization contains the value-related data, only and ignored the metadata:
+The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#format-metadata-metadata-serialization[Metadata Attributes]) but only the value-related data
 
 ////
 [[table-value-data-attributes]]
@@ -178,7 +178,11 @@ valueId is ignored in Value-Only serialization
 
 
 2+|*Structured Non-Value Elements*
-|AssetAdministrationShell a|assetInformation, submodels
+|AssetAdministrationShell a| assetInformation, submodels
+
+====
+Up to now there is no Value-Only serialization for an Asset Administration Shell in use.
+====
 
 |Entity |statements, globalAssetId, specificAssetId
 
@@ -216,7 +220,7 @@ There is no Value-Only serialization for an Operation. However, a Value-Only ser
 
 A submodel element is omitted if no value is defined for it for the requesting submodel or submodel element.
 
-Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier"
+Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier".
 
 
 ==== How-To Value-Only Serialization
@@ -526,7 +530,7 @@ xs:language, xs:normalizedString, xs:token, xs:NMTOKEN, xs:Name, xs:NCName, xs:Q
 
 
 ====
-Note 1: due to the limits in the representation of numbers in JSON, the maximum integer number that can be used without losing precision is 2⁵³-1 (defined as Number.MAX_SAFE_INTEGER). Even if the used data type would allow higher or lower values, they cannot be used if they cannot be represented in JSON. Affected data types are unbounded numeric types xs:decimal, xs:integer, xs:positiveInteger, xs:nonNegativeInteger, xs:negativeInteger, xs:nonPositiveInteger and the bounded type xs:unsignedLong. Other numeric types are not affected. footnote:[cf. https://eclipse-esmf.github.io/samm-specification/2.0.0/datatypes.html (with adjustments for +/-INF, NaN, and language-typed literal support)]
+Note 1: due to the limits in the representation of numbers in JSON, the maximum integer number that can be used without losing precision is 2⁵³-1 (defined as https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER[Number.MAX_SAFE_INTEGER]). Even if the used data type would allow higher or lower values, they cannot be used if they cannot be represented in JSON. Affected data types are unbounded numeric types xs:decimal, xs:integer, xs:positiveInteger, xs:nonNegativeInteger, xs:negativeInteger, xs:nonPositiveInteger and the bounded type xs:unsignedLong. Other numeric types are not affected. footnote:[cf. https://eclipse-esmf.github.io/samm-specification/snapshot/payloads.html (with adjustments for +/-INF, NaN, and language-typed literal support)]
 ====
 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -48,6 +48,14 @@ The following rules shall be adhered to when serializing a submodel with the Ser
 
 * Submodel elements defined in the submodel other than the ones mentioned above are not subject to serialization of that SerializationModifier.
 
+
+
+The following rules shall be adhered to when serializing a submodel element different than a submodel with the SerializationModifier _Value_:
+
+* The submodel element is serialized as an unnamed JSON object.
+* A submodel element is considered a leaf submodel element if it does not contain other submodel elements. A leaf submodel element follows the rules for the different submodel elements considered in the serialization, as described for a submodel above. If it is not a leaf element, the serialization rules must be transitively followed until the value is a leaf submodel element.
+
+
 *Data type to value mapping* footnote:[cf. https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/2.0.0/datatypes.html]
 
 The serialization of submodel element values is described in the following table. The left column “Data Type” shows the data types which can be used for submodel element values. The data types are defined according to the W3C XML Schema (https://www.w3.org/TR/xmlschema-2/#built-in-datatypes and https://www.w3.org/TR/xmlschema-2/#built-in-derived). “Value Range” further explains the possible range of data values for this data type. The right column comprises related examples of the serialization of submodel element values.
@@ -148,7 +156,7 @@ Full serialization of single submodel element _Property_:
 }
 ----
 
-With the SerializationModifier set to _Value,_ the payload is minimized to the following:
+With the SerializationModifier set to _Value,_ the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -157,10 +165,16 @@ With the SerializationModifier set to _Value,_ the payload is minimized to the f
 }
 ----
 
-TODO: Example where precision in value string to ValueOnly to value string is critical.
+If the property itself is the subject for ValueOnly the serialization is minimized to the following:
+[source,json,linenums]
+----
+{
+  5000
+}
+----
 
 
-For a _SubmodelElementCollection,_ the struct is serialized as objects denoted by curly brackets:
+For a _SubmodelElementCollection_, the struct is serialized within a submodel or structured submodel element as objects denoted by curly brackets:
 
 [source,json,linenums]
 ----
@@ -173,7 +187,20 @@ For a _SubmodelElementCollection,_ the struct is serialized as objects denoted b
 }
 ----
 
-For a _SubmodelElementList,_ the struct is serialized as array denoted by square brackets:
+If the _SubmodelElementCollection_ itself is the subject for ValueOnly the serialization is minimized to the following:
+
+[source,json,linenums]
+----
+{
+
+    "NameOfMother": "Martha ExampleFamily",
+    "NameOfFather": "Jonathan ExampleFamily",
+    "NameOfSon": "Clark ExampleFamily"
+
+}
+----
+
+For a _SubmodelElementList,_ the struct is serialized within a submodel or structured submodel element as array denoted by square brackets:
 
 [source,json,linenums]
 ----
@@ -186,7 +213,20 @@ For a _SubmodelElementList,_ the struct is serialized as array denoted by square
 }
 ----
 
-For a _MultiLanguageProperty_ named “Label”, the payload is minimized to the following:
+If the _SubmodelElementList_ itself is the subject for ValueOnly the serialization is minimized to the following:
+
+[source,json,linenums]
+----
+ [
+    "Martha ExampleFamily",
+    "Jonathan ExampleFamily",
+    "Clark ExampleFamily"
+  ]
+----
+
+
+
+For a _MultiLanguageProperty_ named “Label”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -196,6 +236,16 @@ For a _MultiLanguageProperty_ named “Label”, the payload is minimized to the
     {"en": "That's an English label"}
   ]
 }
+----
+
+If the _MultiLanguageProperty_ itself is the subject for ValueOnly the serialization is minimized to the following:
+[source,json,linenums]
+----
+  [
+    {"de": "Das ist ein deutscher Bezeichner"},
+    {"en": "That's an English label"}
+  ]
+
 ----
 
 
@@ -210,7 +260,7 @@ Note: in accordance with IETF https://tools.ietf.org/html/rfc5646#page-5[RFC 564
 ----
 
 
-For a _Range_ named “TorqueRange”, the payload is minimized to the following:
+For a _Range_ named “TorqueRange”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -222,7 +272,18 @@ For a _Range_ named “TorqueRange”, the payload is minimized to the following
 }
 ----
 
-For a _ReferenceElement_ named “MaxRotationSpeedReference”, the payload is minimized to the following:
+If the _Range_ itself is the subject for ValueOnly the serialization is minimized to the following:
+[source,json,linenums]
+
+[source,json,linenums]
+----
+{
+    "min": 3,
+    "max": 15
+}
+----
+
+For a _ReferenceElement_ named “MaxRotationSpeedReference”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -243,7 +304,8 @@ For a _ReferenceElement_ named “MaxRotationSpeedReference”, the payload is m
 }
 ----
 
-For the same _ReferenceElement,_ the payload is minimized to the following in case the _Reference_ is of subtype _GlobalReference_:
+For an _ReferenceElement_ representing an _ExternalReference_ with the same name the payload within a submodel or structured submodel element is minimized to the following:
+
 
 [source,json,linenums]
 ----
@@ -260,7 +322,23 @@ For the same _ReferenceElement,_ the payload is minimized to the following in ca
 }
 ----
 
-For a _File_ named “Document”, the payload is minimized to the following:
+If the _Reference_ itself is the subject for ValueOnly the serialization is minimized to the following:
+[source,json,linenums]
+
+[source,json,linenums]
+----
+{
+    "type": "ExternalReference",
+    "keys": [
+      {
+        "type": "GlobalReference",
+        "value": "0173-1#02-BAA120#008"
+      }
+    ]
+}
+----
+
+For a _File_ named “Document”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -272,7 +350,19 @@ For a _File_ named “Document”, the payload is minimized to the following:
 }
 ----
 
-For a _Blob_ named “Library”, the payload is minimized to the following if the SerializationModifier _Extent_ is set to *_WithoutBLOBValue_*
+If the _File_ itself is the subject for ValueOnly the serialization is minimized to the following:
+[source,json,linenums]
+
+[source,json,linenums]
+----
+{
+    "contentType": "application/pdf",
+    "value": "SafetyInstructions.pdf"
+}
+----
+
+
+For a _Blob_ named “Library”, the payload within a submodel or structured submodel element is minimized to the following if the SerializationModifier _Extent_ is set to *_WithoutBLOBValue_*
 
 [source,json,linenums]
 ----
@@ -294,8 +384,18 @@ If the SerializationModifier Extent is set to *_WithBlobValue_*, there is an add
   }
 }
 ----
+ 
+If the _Blob_ itself is the subject for ValueOnly the serialization for Extent set to *_WithBlobValue_  is minimized to the following:
 
-For a _RelationshipElement_ named “CurrentFlowsFrom”, the payload is minimized to the following:
+[source,json,linenums]
+----
+{
+    "contentType": "application/octet-stream",
+    "value": "VGhpcyBpcyBteSBibG9i"
+}
+----
+
+For a _RelationshipElement_ named “CurrentFlowsFrom”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -331,7 +431,41 @@ For a _RelationshipElement_ named “CurrentFlowsFrom”, the payload is minimiz
 }
 ----
 
-For an _AnnotatedRelationshipElement_ named “CurrentFlowFrom”, with an annotated _Property_-DataElement “AppliedRule”, the payload is minimized to the following:
+If the _RelationshipElement_ itself is the subject for ValueOnly the serialization is minimized to the following:
+
+[source,json,linenums]
+----
+{
+    "first": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "PlusPole"
+        }
+      ]
+    },
+    "second": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/0/1234859123490"
+        },
+        {
+          "type": "Property",
+          "value": "MinusPole"
+        }
+      ]
+    }
+}
+----
+
+For an _AnnotatedRelationshipElement_ named “CurrentFlowFrom”, with an annotated _Property_-DataElement “AppliedRule”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -372,7 +506,46 @@ For an _AnnotatedRelationshipElement_ named “CurrentFlowFrom”, with an annot
 }
 ----
 
-For an _Entity_ named “MySubAssetEntity”, the payload is minimized to the following:
+If the _RelationshipElementAnnotation_ itself is the subject for ValueOnly the serialization is minimized to the following:
+
+[source,json,linenums]
+----
+{
+    "first": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "PlusPole"
+        }
+      ]
+    },
+    "second": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/0/1234859123490"
+        },
+        {
+          "type": "Property",
+          "value": "MinusPole"
+        }
+      ]
+    },
+    "annotation": [
+      {
+        "AppliedRule": "TechnicalCurrentFlowDirection"
+      }
+    ]
+}
+----
+
+For an _Entity_ named “MySubAssetEntity”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -395,7 +568,28 @@ For an _Entity_ named “MySubAssetEntity”, the payload is minimized to the fo
 }
 ----
 
-For a BasicEventElement named “MyBasicEvent”, the payload is minimized to the following:
+If the _Entity_ itself is the subject for ValueOnly the serialization is minimized to the following:
+
+[source,json,linenums]
+----
+{
+    "statements": {
+      "MaxRotationSpeed": 5000
+    },
+    "entityType": "SelfManagedEntity",
+    "globalAssetId": {
+      "type": "ExternalReference",
+      "keys": [
+        {
+          "type": "GlobalReference",
+          "value": "http://customer.com/demo/asset/1/1/MySubAsset"
+        }
+      ]
+    }
+}
+----
+
+For a BasicEventElement named “MyBasicEvent”, the payload within a submodel or structured submodel element is minimized to the following:
 
 [source,json,linenums]
 ----
@@ -415,6 +609,27 @@ For a BasicEventElement named “MyBasicEvent”, the payload is minimized to th
       ]
     }
   }
+}
+----
+
+If the _BasicEventElement_ itself is the subject for ValueOnly the serialization is minimized to the following:
+
+[source,json,linenums]
+----
+{
+    "observed": {
+      "type": "ModelReference",
+      "keys": [
+        {
+          "type": "Submodel",
+          "value": "http://customer.com/demo/aas/1/1/1234859590"
+        },
+        {
+          "type": "Property",
+          "value": "CurrentValue"
+        }
+      ]
+    }
 }
 ----
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -119,7 +119,7 @@ In the following the grammar for Value-Only serialization is defined in a formal
 
 <value-of-File> ::= 
     '{
-        "Contenttype":' <value-ContentType>','
+        "contentType":' <value-ContentType>','
        '"value":' <value-PathType>
     '}'
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -13,6 +13,7 @@ Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, d
 
 === Format "Value" (Value-Only Serialization) in JSON
 
+==== Fields for Value-Only Serialization
 
 In many cases, applications using data from Asset Administration Shells already know the Submodel regarding its structure, attributes, and semantics, for example via the used Submodel Template. Consequently, there is not always a need to receive the entire model information. Instead, applications are most likely only interested in the values of the modelled data. Furthermore, having limited processing power or limited bandwidth, one use case of the Format "Value" is to transfer data as efficiently as possible. Semantics and data might be split into two separate architecture building blocks. For example, a database would suit the needs for querying semantics, while a device would only provide the data at runtime. Two separate requests make it possible to build up a user interface (UI) and show new upcoming values highly efficiently.
 
@@ -28,40 +29,158 @@ Values are only available for
 
 Capabilities are excluded from the Value-Only serialization scope since only data containing elements are in the focus. They are consequently omitted in the serialization.
 
-The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#format-metadata-metadata-serialization[Metadata Attributes]). So it is quite the other way around:
+The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#format-metadata-metadata-serialization[Metadata Attributes]). So the serialization contains the value-related data, only and ignored the metadata:
 
-[[table:value-data-attributes]]
-.Metadata Attributes
+[[table-value-data-attributes]]
+.Value-Only Attributes
 [%autowidth, width="100%", cols="48%,52%",options="header",]
 |===
-|*Class Name* |*Fields for Value-Only representationfootnote:[(value) means that the attribute name is not relevant, only its value, 
-for the other attributes the attribute itself will be seen in the payload]*
+|*Class Name* |*Fields for Value-Only representationfootnote:[ attribute in parenthesis (like e.g. (value)) means that the attribute name is not displayed, only its Value-Only serialization. 
+For the other attributes the attribute itself will be part of the serialization]*
 2+|*Identifiables*
-|AssetAdministrationShell |assetInformation, submodels
-|Submodel |submodelElements
-2+|*SubmodelElements*
-|SubmodelElementCollection | (value)
-|SubmodelElementList | (value)
+|AssetAdministrationShell a|assetInformation, submodels
+|Submodel a| (submodelElements)
+
+====
+Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier".
+====
+
+|*SubmodelElements* a| 
+
+====
+Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier".
+====
+
+|SubmodelElementCollection a| (value) 
+
+====
+If the collection contains submodel elements of type
+ Operation or Capability: these are ignored in the Value-Only serialization
+====
+
+|SubmodelElementList a| (value) 
+
+if defined: type equal to SubmodelElementList/valueTypeListElement
+
+====
+If the submodel element list is part the Value-Only serialization of its parent element (e.g. in the context of a submodel or submodel element collection) and the list consists of submodel elements of type Operation or Capability the complete list is ignored. 
+
+If the Value-Only serialization of the list is explicitly requested without context a corresponding error message shall be returned. 
+====
+
 |Entity |statements, globalAssetId, specificAssetId
-|BasicEventElement |observed
-|Capability |--
-|Operation |--
+|BasicEventElement a|observed
+|Capability a| -
+|Operation a| -
+
+====
+There is not Value-Only serialization for an Operation. However, a Value-Only serialization is useful for its arguments when executing the operation (see Value-Only serialization of "OperationVariable")
+====
+
+|RelationshipElement a|first, second
+|AnnotatedRelationshipElement a|first, second, annotations
+
 2+|*DataElements*
-|Property | (value)
-|MultilanguageProperty | (value)
-|Range |min, max
-|ReferenceElement |value
-|RelationshipElement |first, second
-|AnnotatedRelationshipElement |first, second, annotations
-|Blob |value, contentType
-|File |value, contentType
+|Property a| (value)
+
+type equal to Property/valueType
+
+====
+valueId is ignored in Value-Only serialization
+====
+|MultilanguageProperty a| (value)
+
+====
+valueId is ignored in Value-Only serialization
+====
+|Range a|min, max
+
+type equal to Range/valueType
+
+====
+In the Value-Only serialization only number ranges are supported
+====
+
+|ReferenceElement a|(value)
+
+|Blob a|value, contentType
+|File a|value, contentType
+
+2+|*Data Types*
+|OperationVariable a| (value)
+
+|MultiLanguageTextType a| The value of this type is identicial to its "Normal"-format serialization: it consists of a list of pairs: a language tag and the value in the corresponding language
+
+[listing]
+....
+<language-tag> ::= 
+	language tag as defined for values of type langString, i.e.
+	in accordance with IETF https://tools.ietf.org/html/rfc5646#page-5[RFC 5646], 
+	the language names match the following regular expression:
+
+		^[a-z]\{2,4}(-[A-Z][a-z]\{3})?(-([A-Z]\{2}|[0-9]\{3}))?$
+	
+....	
+
+	e.g. "en" for Englisch
 |===
 
-Exception:
-Property/valueId and MultiLanguagePropertyId are also no Metadata attributes. However, they are ignored in the Value-Only serialization.
 
 A submodel element is omitted if no value is defined for it for the requesting submodel or submodel element.
 
+==== How-To Value-Only Serialization
+
+The Value-Only serialization is defined by the following rules:
+
+* If the submodel element has an attribute with name "value" then its Value-Only serialization corresponds directly to this value.
+In some cases the type of the value is defined via another attribute: this needs to be explicitly defined as done in xref:table-value-data-attributes[] for example for "Property".
+
+====
+EXAMPLE: 
+The JSON Value-Only serialization for the  property "MaxRotationSpeed" with "Property/valueType" equal to "xs:int" looks like this:
+    
+[source,json,linenums]
+----
+5000
+----
+    
+====
+
+* If the submodel element has no attribute with name "value" then the attributes that are value-related need to be explicitly identified as such, for example by a table as defined in xref:table-value-data-attributes[]. These attributes are part of the serialization with their name, the name being the value of the attribute "idShort". 
+
+====
+EXAMPLE: 
+For a _SubmodelElementCollection_ named "ExampleFamily" with four string attributes "NameOfMother", "NameOfFather" and "NameOfSon" of type "Property" and one attribute "CalculateAge" of type "Operation", the Value-Only JSON payload is minimized to the following,
+i.e. the name of the SubmodelElementCollection is not part of the Value-Only serialization and attribute "CalculateAge" is ignored:
+    
+[source,json,linenums]
+----
+{
+    "NameOfMother": "Martha ExampleFamily",
+    "NameOfFather": "Jonathan ExampleFamily",
+    "NameOfSon": "Clark ExampleFamily"
+}
+----
+    
+====
+
+* Submodel is an exception. Its attribute "submodelElements" is treated like the attribute "value" of a submodel element collection.
+
+* For complex types the serialization is identical to the "Normal"-format serialization. If this is not the case its serialization needs to be explicitly defined.
+
+====
+EXAMPLE:
+For a _MultiLanguageProperty_ of type "MultiLanguageTextType" the Value-Only payload is minimized to the following:
+[source,json,linenums]
+----
+[
+    {"de": "Das ist ein deutscher Bezeichner"},
+    {"en": "That's an English label"}
+]
+
+====
+
+////
 ==== Grammar Value-Only Serialization
 
 In the following the grammar for Value-Only serialization is defined in a formal way:
@@ -210,7 +329,7 @@ In the following the grammar for Value-Only serialization is defined in a formal
 	value of type Identifier
 
 ....
-
+////
 
 ==== Data Type to Value Mapping
 
@@ -604,7 +723,8 @@ For a BasicEventElement named “MyBasicEvent”, the Value-Only-payload is mini
 
 ==== JSON-Schema for the ValueOnly-Serialization
 
-The following JSON-Schema represents the validation schema for the ValueOnly-Serialization of submodel elements. This holds true for all submodel elements mentioned in the previous clause except for _SubmodelElementCollections_. Since _SubmodelElementCollections_ are treated as objects containing submodel elements of any kind, the integration into the same validation schema would result in a circular reference or ambiguous results ignoring the actual validation of submodel elements other than _SubmodelElementCollections_. Hence, the same validation schema must be applied for each _SubmodelElementCollection_ within a submodel element hierarchy. In this case, it may be necessary to create a specific JSON-Schema for the individual use case. The _SubmodelElementCollection_ is added to the following schema for completeness and clarity. It is, however, not referenced from the _SubmodelElementValue_-oneOf-Enumeration due to the reasons mentioned above. +
+The following JSON-Schema represents the validation schema for the ValueOnly-Serialization of submodel elements. This holds true for all submodel elements mentioned in the previous clause except for _SubmodelElementCollections_. Since _SubmodelElementCollections_ are treated as objects containing submodel elements of any kind, the integration into the same validation schema would result in a circular reference or ambiguous results ignoring the actual validation of submodel elements other than _SubmodelElementCollections_. Hence, the same validation schema must be applied for each _SubmodelElementCollection_ within a submodel element hierarchy. In this case, it may be necessary to create a specific JSON-Schema for the individual use case. The _SubmodelElementCollection_ is added to the following schema for completeness and clarity. It is, however, not referenced from the _SubmodelElementValue_-oneOf-Enumeration due to the reasons mentioned above. 
+
 See Annex B for an example that validates against this schema.
 
 [source,json,linenums]
@@ -623,7 +743,7 @@ See Annex B for an example that validates against this schema.
         "second": {
           "$ref": "#/definitions/ReferenceValue"
         },
-        "annotation": {
+        "annotations": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ValueOnly"
@@ -633,7 +753,6 @@ See Annex B for an example that validates against this schema.
       "required": [
         "first",
         "second",
-        "annotation"
       ],
       "additionalProperties": false
     },
@@ -751,33 +870,6 @@ See Annex B for an example that validates against this schema.
     },
     "NumberValue": {
       "type": "number",
-      "additionalProperties": false
-    },
-    "OperationRequestValueOnly": {
-      "inoutputArguments": {
-        "$ref": "#/definitions/ValueOnly"
-      },
-      "inputArguments": {
-        "$ref": "#/definitions/ValueOnly"
-      },
-      "timestamp": {
-        "type": "string",
-        "pattern": "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)(Z|\\+00:00|-00:00)$"
-      },
-      "additionalProperties": false
-    },
-    "OperationResultValueOnly": {
-      "executionState": {
-        "type": "string",
-        "enum": ["Initiated", "Running", "Completed", "Canceled", "string",
-                 "Failed", "Timeout"]
-      },
-      "inoutputArguments": {
-        "$ref": "#/definitions/ValueOnly"
-      },
-      "outputArguments": {
-        "$ref": "#/definitions/ValueOnly"
-      },
       "additionalProperties": false
     },
     "PropertyValue": {

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -218,7 +218,7 @@ If the _SubmodelElementList_ itself is the subject for ValueOnly the serializati
 
 [source,json,linenums]
 ----
- [
+[
     "Martha ExampleFamily",
     "Jonathan ExampleFamily",
     "Clark ExampleFamily"

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -55,7 +55,7 @@ The following rules shall be adhered to when serializing a submodel element diff
 * The submodel element is serialized as an unnamed JSON object.
 * A submodel element is considered a leaf submodel element if it does not contain other submodel elements. A leaf submodel element follows the rules for the different submodel elements considered in the serialization, as described for a submodel above. If it is not a leaf element, the serialization rules must be transitively followed until the value is a leaf submodel element.
 
-Optional submodel elements are omitted if not specified for the requesting submodel or submodel element.
+A submodel element is omitted if no value is defined for it for the requesting submodel or submodel element.
 
 *Data type to value mapping* footnote:[cf. https://openmanufacturingplatform.github.io/sds-documentation/bamm-specification/2.0.0/datatypes.html]
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -6,8 +6,6 @@ https://creativecommons.org/licenses/by/4.0/).
 
 SPDX-License-Identifier: CC-BY-4.0
 
-Illustrations:
-Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
 ////
 
 
@@ -31,6 +29,7 @@ Capabilities are excluded from the Value-Only serialization scope since only dat
 
 The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#format-metadata-metadata-serialization[Metadata Attributes]). So the serialization contains the value-related data, only and ignored the metadata:
 
+////
 [[table-value-data-attributes]]
 .Value-Only Attributes
 [%autowidth, width="100%", cols="48%,52%",options="header",]
@@ -42,13 +41,13 @@ For the other attributes the attribute itself will be part of the serialization]
 |Submodel a| (submodelElements)
 
 ====
-Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier".
+Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier"
 ====
 
 |*SubmodelElements* a| 
 
 ====
-Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier".
+Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier"
 ====
 
 |SubmodelElementCollection a| (value) 
@@ -74,7 +73,7 @@ If the Value-Only serialization of the list is explicitly requested without cont
 |Operation a| -
 
 ====
-There is not Value-Only serialization for an Operation. However, a Value-Only serialization is useful for its arguments when executing the operation (see Value-Only serialization of "OperationVariable")
+There is no Value-Only serialization for an Operation. However, a Value-Only serialization is useful for its arguments when executing the operation (see Value-Only serialization of "OperationVariable")
 ====
 
 |RelationshipElement a|first, second
@@ -106,50 +105,154 @@ In the Value-Only serialization only number ranges are supported
 |Blob a|value, contentType
 |File a|value, contentType
 
-2+|*Data Types*
+2+|*Non-Referables*
 |OperationVariable a| (value)
 
-|MultiLanguageTextType a| The value of this type is identicial to its "Normal"-format serialization: it consists of a list of pairs: a language tag and the value in the corresponding language
 
-[listing]
-....
-<language-tag> ::= 
-	language tag as defined for values of type langString, i.e.
-	in accordance with IETF https://tools.ietf.org/html/rfc5646#page-5[RFC 5646], 
-	the language names match the following regular expression:
 
-		^[a-z]\{2,4}(-[A-Z][a-z]\{3})?(-([A-Z]\{2}|[0-9]\{3}))?$
-	
-....	
 
-	e.g. "en" for Englisch
 |===
 
 
+////
+
+[[table-value-data-attributes]]
+.Value-Only Attributes
+[%autowidth, width="100%", cols="48%,52%",options="header",]
+|===
+|*Class Name* |*Fields for Value-Only representationfootnote:[ attribute in parenthesis (like e.g. (value)) means that the attribute name is not displayed, only its Value-Only serialization. 
+For the other attributes the attribute itself will be part of the serialization]*
+
+2+|*Structured Value Elements*
+|Submodel a| (submodelElements)
+
+|SubmodelElementCollection a| (value) 
+
+====
+If the collection contains submodel elements of type
+ Operation or Capability: these are ignored in the Value-Only serialization
+====
+
+
+
+2+|*List Value Elements*
+
+|SubmodelElementList a| (value) 
+
+type of values of the contained elements equal to SubmodelElementList/typeValueListElement
+
+if defined (e.g. if typeValueListElement equal to Property or Range): value type of a single element contained in the list equal to SubmodelElementList/valueTypeListElement 
+
+====
+If the submodel element list is part the Value-Only serialization of its parent element (e.g. in the context of a submodel or submodel element collection) and the list consists of submodel elements of type Operation or Capability the complete list is ignored. 
+
+If the Value-Only serialization of the list is explicitly requested without context a corresponding error message shall be returned. 
+====
+
+2+|*Pure Value Elements* 
+|Property a| (value)
+
+type of value equal to Property/valueType
+
+====
+valueId is ignored in Value-Only serialization
+====
+
+|MultilanguageProperty a| (value) _tagged with language code_
+
+====
+valueId is ignored in Value-Only serialization
+====
+
+|ReferenceElement a|(value) _value corresponds to default serialization of its type "Reference"_
+
+|OperationVariable a| (value) _value corresponds to the Value-Only serialization of the corresponding SubmodelElement subtype_
+
+2+|*Complex Value Elements* 
+|Blob a|value, contentType
+
+|File a|value, contentType
+
+
+
+
+
+2+|*Structured Non-Value Elements*
+|AssetAdministrationShell a|assetInformation, submodels
+
+|Entity |statements, globalAssetId, specificAssetId
+
+|BasicEventElement a|observed
+
+|RelationshipElement a|first, second
+
+|AnnotatedRelationshipElement a|first, second, annotations
+
+
+
+|Range a|min, max
+
+type equal to Range/valueType
+
+====
+In the Value-Only serialization only number ranges are supported
+====
+
+
+|Capability a| -
+
+====
+There is no Value-Only serialization for a Capability. 
+====
+
+|Operation a| -
+
+====
+There is no Value-Only serialization for an Operation. However, a Value-Only serialization is useful for its arguments when executing the operation (see Value-Only serialization of "OperationVariable")
+====
+
+
+|===
+
 A submodel element is omitted if no value is defined for it for the requesting submodel or submodel element.
+
+Qualifiers are ignored. This also holds for qualifiers of kind "ValueQualifier"
+
 
 ==== How-To Value-Only Serialization
 
 The Value-Only serialization is defined by the following rules:
 
-* If the submodel element has an attribute with name "value" then its Value-Only serialization corresponds directly to this value.
-In some cases the type of the value is defined via another attribute: this needs to be explicitly defined as done in xref:table-value-data-attributes[] for example for "Property".
+===== *Value Elements*
+
+If the submodel element has an attribute with name "value" then its Value-Only serialization typically corresponds directly to this value.
+
+For Value Elements see Structured Value Elements and
+ Pure Value Elements as well as Complex Value Elements in xref:table-value-data-attributes[]).
+
+In some cases the type of the value is defined via another attribute: this needs to be explicitly defined, see xref:table-value-data-attributes[], for example for "Property".
+
+For a Structured Value Element the attributes are part of the serialization with their name, the name being the value of the attribute "idShort". 
+
+If the serialization does not directly corresponds to this value this needs to be explicitly defined, see xref:table-value-data-attributes[], for example for "File".
+
+Submodel is an exception. Its attribute "submodelElements" is treated like the attribute "value" of a submodel element collection.
+
+A List Value Element is serialized as an array.
 
 ====
-EXAMPLE: 
+EXAMPLE for a Pure Value Element: 
 The JSON Value-Only serialization for the  property "MaxRotationSpeed" with "Property/valueType" equal to "xs:int" looks like this:
     
 [source,json,linenums]
 ----
 5000
 ----
-    
-====
-
-* If the submodel element has no attribute with name "value" then the attributes that are value-related need to be explicitly identified as such, for example by a table as defined in xref:table-value-data-attributes[]. These attributes are part of the serialization with their name, the name being the value of the attribute "idShort". 
 
 ====
-EXAMPLE: 
+
+====
+EXAMPLE for a Structured Value Element: 
 For a _SubmodelElementCollection_ named "ExampleFamily" with four string attributes "NameOfMother", "NameOfFather" and "NameOfSon" of type "Property" and one attribute "CalculateAge" of type "Operation", the Value-Only JSON payload is minimized to the following,
 i.e. the name of the SubmodelElementCollection is not part of the Value-Only serialization and attribute "CalculateAge" is ignored:
     
@@ -164,12 +267,46 @@ i.e. the name of the SubmodelElementCollection is not part of the Value-Only ser
     
 ====
 
-* Submodel is an exception. Its attribute "submodelElements" is treated like the attribute "value" of a submodel element collection.
+====
+EXAMPLE for a Complex Value Element, a "File" submodel element:
 
-* For complex types the serialization is identical to the "Normal"-format serialization. If this is not the case its serialization needs to be explicitly defined.
+[source,json,linenums]
+----
+{
+    "contentType": "application/pdf",
+    "value": "SafetyInstructions.pdf"
+}
+----
 
 ====
-EXAMPLE:
+
+===== *Non-Value Elements*
+
+If the submodel element has no attribute with name "value" then the attributes that are value-related need to be explicitly identified as such, see Structured Non-Value Elements in xref:table-value-data-attributes[]. These attributes are part of the serialization with their name. 
+
+There some Non-Value Elements there is no Value-Only serialization defined at all, example "Cabability".
+
+====
+EXAMPLE for a Structured Non-Value Element
+
+[source,json,linenums]
+----
+{
+    "min": 3,
+    "max": 15
+}
+----
+
+====
+
+===== *Serialization of value itself* 
+
+The serialization of a value with a type that is not listed in xref:table-value-data-attributes[] is identical to its default serialization. This holds for attributes of primitive data types like LangStringSet or for attributes with non-primitive data types like "Reference".
+
+If this is would not the case its serialization needs to be explicitly defined.
+
+====
+EXAMPLE for value with type not corresponding to an element in xref:table-value-data-attributes[]:
 For a _MultiLanguageProperty_ of type "MultiLanguageTextType" the Value-Only payload is minimized to the following:
 [source,json,linenums]
 ----
@@ -383,7 +520,7 @@ Note: the examples are written in RDF/Turtle syntax, and only "Hello" and "Hallo
 
 |===
 
-The following types defined by the XSD and RDF specifications are explicitly omitted for serialization. This is ensured because they are not part of enumerations xref:IDTA-01001_Metamodel_DataTypes.adoc#DataTypeDefXsd[DataTypeDefXsd] and xref:IDTA-01001_Metamodel_DataTypes.adoc#DataTypeDefRdf[DataTypeDefRdf]:
+The following types defined by the XSD and RDF specifications are explicitly omitted for serialization. This is ensured because they are not part of enumerations xref:page$Spec/IDTA-01001_Metamodel_DataTypes.adoc#DataTypeDefXsd[DataTypeDefXsd] and xref:page$Spec/IDTA-01001_Metamodel_DataTypes.adoc#DataTypeDefRdf[DataTypeDefRdf]:
 
 xs:language, xs:normalizedString, xs:token, xs:NMTOKEN, xs:Name, xs:NCName, xs:QName, xs:ENTITY, xs:ID, xs:IDREF, xs:NOTATION, xs:IDREFS, xs:ENTITIES, xs:NMTOKENS, rdf:HTML and rdf:XMLLiteral.
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -222,7 +222,7 @@ If the _SubmodelElementList_ itself is the subject for ValueOnly the serializati
     "Martha ExampleFamily",
     "Jonathan ExampleFamily",
     "Clark ExampleFamily"
-  ]
+]
 ----
 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/IDTA-01001_ValueOnly.adoc
@@ -28,7 +28,7 @@ Values are only available for
 
 Capabilities are excluded from the Value-Only serialization scope since only data containing elements are in the focus. They are consequently omitted in the serialization.
 
-The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#table:meta-data-attributes[Metadata Attributes]). So it is quite the other way around:
+The Value-Only Format does not contain Metadata attributes (see xref:IDTA-01001_Mappings.adoc#format-metadata-metadata-serialization[Metadata Attributes]). So it is quite the other way around:
 
 [[table:value-data-attributes]]
 .Metadata Attributes
@@ -86,16 +86,16 @@ In the following the grammar for Value-Only serialization is defined in a formal
 
 <value-only-of-SubmodelElementCollection> ::=
      '{' 
-        {<jd><idShort-of-sme><jd>':' <value-only-of-sme>','}*  
-         <jd><idShort-of-sme><jd>':' <value-only-of-sme>
+        {'"'<idShort-of-sme>'"'':' <value-only-of-sme>','}*  
+         '"'<idShort-of-sme>'"'':' <value-only-of-sme>
         |
         ''
      '}'
 
 <value-only-of-SubmodelElementList> ::= 
     '[' 
-       {<value-only-of-sme>','}* 
-	    <value-only-of-sme> | 
+       {<value-only-of-sme>','}*
+       <value-only-of-sme> | 
        ''
     ']' 
     
@@ -109,8 +109,8 @@ In the following the grammar for Value-Only serialization is defined in a formal
    ']'
 
 <value-only-of-Range> ::=  
-    '{  
-		"min":' <value of Range>',' 
+    '{
+        "min":' <value of Range>',' 
        '"max":' <value of Range>
     '}'
 
@@ -140,16 +140,16 @@ In the following the grammar for Value-Only serialization is defined in a formal
         "first"': <value-Reference>','
        '"second"': <value-Reference>[','
        '"annotations": ['  
-            {<jd><idShort-of-sme><jd>':' <value-only-of-DataElement>','}*  
-             <jd><idShort-of-DataElement><jd>':'  <value-only-of-sme>
+            {'"'<idShort-of-sme>'"'':' <value-only-of-DataElement>','}*  
+             '"'<idShort-of-DataElement>'"'':'  <value-only-of-sme>
         ']'
     '}'
         
 <value-only-of-Entity> ::=
     '{'
       ['"statements": ['
-          {<jd><idShort-of-sme><jd>':' <value-only-of-sme>','}*  
-           <jd><idShort-of-sme><jd>':' <value-only-of-sme>
+          {'"'<idShort-of-sme>'"'':' <value-only-of-sme>','}*  
+           '"'<idShort-of-sme>'"'':' <value-only-of-sme>
         '],']
        '"entityType":' <value-EntityType>[',' (
        '"globalAssetId":' <value-Identifier>[','
@@ -209,17 +209,6 @@ In the following the grammar for Value-Only serialization is defined in a formal
 <value-Identifier> ::= 
 	value of type Identifier
 
-<jd> ::= 
-	<json-delimiter>  
-
-<sd> ::= 
-	<string-delimiter>  
-
-<json-delimiter> ::= 
-	'"'
-
-<string-delimiter> ::= 
-	'"'
 ....
 
 
@@ -275,7 +264,7 @@ Note: the examples are written in RDF/Turtle syntax, and only "Hello" and "Hallo
 
 |===
 
-The following types defined by the XSD and RDF specifications are explicitly omitted for serialization. This is ensured because they are not part of enumerations xref:IDTA-01001_Metamodel_DataTypes.adoc#[DataTypeDefXsd] and xref:IDTA-01001_Metamodel_DataTypes.adoc#[DataTypeDefRdf]:
+The following types defined by the XSD and RDF specifications are explicitly omitted for serialization. This is ensured because they are not part of enumerations xref:IDTA-01001_Metamodel_DataTypes.adoc#DataTypeDefXsd[DataTypeDefXsd] and xref:IDTA-01001_Metamodel_DataTypes.adoc#DataTypeDefRdf[DataTypeDefRdf]:
 
 xs:language, xs:normalizedString, xs:token, xs:NMTOKEN, xs:Name, xs:NCName, xs:QName, xs:ENTITY, xs:ID, xs:IDREF, xs:NOTATION, xs:IDREFS, xs:ENTITIES, xs:NMTOKENS, rdf:HTML and rdf:XMLLiteral.
 
@@ -478,7 +467,6 @@ for the API a special JSON query parameter, the SerializationModifier _Extent_, 
 ----
 {
     "contentType": "application/octet-stream"
-  }
 }
 ----
 
@@ -561,7 +549,7 @@ For an _AnnotatedRelationshipElement_ named “CurrentFlowFrom”, with an annot
         }
       ]
     },
-    "annotation": [
+    "annotations": [
       {
         "AppliedRule": "TechnicalCurrentFlowDirection"
       }
@@ -675,7 +663,6 @@ See Annex B for an example that validates against this schema.
       },
       "required": [
         "contentType",
-        "value"
       ],
       "additionalProperties": false
     },
@@ -705,10 +692,6 @@ See Annex B for an example that validates against this schema.
           }
         }
       },
-      "required": [
-        "statements",
-        "entityType"
-      ],
       "additionalProperties": false
     },
     "FileValue": {


### PR DESCRIPTION
Complete rework of chapter "Value-Only" (IDTA-01001_ValueOnly.adoc)

Examples added for $value payloads other than submodel to make it easy to understand after example for payload of element within Submodel or structured element.

Aditionally editorial changes were made w.r.t. linking (xref).