### PR TITLE
Change /3/0 to /3/1 semanticId for MM elements

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ChangeLog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/IDTA-01001_ChangeLog.adoc
@@ -53,12 +53,7 @@ Major Changes:
 * Entity/entityType and Constraint AASd-014: entityType now optional (https://github.com/admin-shell-io/aas-specs/issues/287[#287])
 * Relaxation of grammar for semantic IDs for metamodel elements in the context of data specifications
 (https://github.com/admin-shell-io/aas-specs/issues/307[#307])
-* Individual versioning of metamodel element IDs 
-(https://github.com/admin-shell-io/aas-specs/issues/366[#366])
-(note: the version of many 
-class metamodel IDs needed to be increased to 3.1 due to the change of data types 
-Identifier and idShort of Referable) 
-    ** Adding metamodel element IDs to tables themselves (before only grammar)
+
 * Terms and Definitions adopted to IEC 63278-1:2023 (before IEC 63278-1 Draft July 2022 was the basis), 
 (https://github.com/admin-shell-io/aas-specs/issues/365[#365])
 also abbreviations partly adopted; changes:
@@ -75,12 +70,15 @@ also abbreviations partly adopted; changes:
 (https://github.com/admin-shell-io/aas-specs/issues/350[#350])
 	** introduce equivalent matching and rename exact matching to value matching
 	** added notes 
+* (Editorial) Adding metamodel element IDs to tables themselves for easier usage (besides grammar defining how to derive them)
+(https://github.com/admin-shell-io/aas-specs/issues/366[#366])
 * Transfer from .docx to asciidoc (.adoc) and maintenance in github
 
 
 Minor Changes:
 
 * editorial changes
+* improve explanation for recommendation to use external references for semanticId (https://github.com/admin-shell-io/aas-specs/issues/376[#376])
 
 
 === Metamodel Changes V3.1 vs. V3.0

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Referencing.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Referencing.adoc
@@ -89,15 +89,15 @@ a|Unique reference in its name space |xref:Key[Key] |1..*
 |Enumeration: e|[[ReferenceTypes]]ReferenceTypes
 h|Explanation: |Enumeration for denoting whether an element is an external or model reference
 |Set of: |--
-h|ID: | `\https://admin-shell.io/aas/3/0/ReferenceTypes`  
+h|ID: | `\https://admin-shell.io/aas/3/1/ReferenceTypes`  
 
 .2+h|Literal h| ID
    h|Explanation
    
-.2+e|ExternalReference | `\https://admin-shell.io/aas/3/0/ReferenceTypes/ExternalReference`
+.2+e|ExternalReference | `\https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference`
 a|External reference
 
-.2+e|ModelReference | `\https://admin-shell.io/aas/3/0/ReferenceTypes/ExternalReference/ExternalReference`
+.2+e|ModelReference | `\https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference/ExternalReference`
 a|Model reference
 |===
 
@@ -155,31 +155,31 @@ image::image52.png[]
 |Enumeration: e|[[KeyTypes]]KeyTypes
 h|Explanation: a|Enumeration of different key value types within a key
 |Set of: |xref:FragmentKeys[FragmentKeys]; xref:AasReferables[AasReferables], xref:GloballyIdentifiables[GloballyIdentifiables]
-h|ID: | `\https://admin-shell.io/aas/3/0/KeyTypes`  
+h|ID: | `\https://admin-shell.io/aas/3/1/KeyTypes`  
 
 .2+h|Literal h| ID
    h|Explanation
 
 
-.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/0/KeyTypes/AnnotatedRelationshipElement`
+.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/1/KeyTypes/AnnotatedRelationshipElement`
 a|Annotated relationship element
 
-.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/0/KeyTypes/AssetAdministrationShell`
+.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/1/KeyTypes/AssetAdministrationShell`
 a|Asset Administration Shell
 
-.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/0/KeyTypes/BasicEventElement`
+.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/1/KeyTypes/BasicEventElement`
 a|Basic event element
 
-.2+e|Blob | `\https://admin-shell.io/aas/3/0/KeyTypes/Blob`
+.2+e|Blob | `\https://admin-shell.io/aas/3/1/KeyTypes/Blob`
 a|Blob
 
-.2+e|Capability | `\https://admin-shell.io/aas/3/0/KeyTypes/Capability`
+.2+e|Capability | `\https://admin-shell.io/aas/3/1/KeyTypes/Capability`
 a|Capability
 
-.2+e|ConceptDescription | `\https://admin-shell.io/aas/3/0/KeyTypes/ConceptDescription`
+.2+e|ConceptDescription | `\https://admin-shell.io/aas/3/1/KeyTypes/ConceptDescription`
 a|Concept Description
 
-.2+e|DataElement | `\https://admin-shell.io/aas/3/0/KeyTypes/DataElement`
+.2+e|DataElement | `\https://admin-shell.io/aas/3/1/KeyTypes/DataElement`
 a|
 Data Element
 
@@ -189,10 +189,10 @@ Note: data elements are abstract, i.e. if a key uses "DataElement", the referenc
 ====
 
 
-.2+e|Entity | `\https://admin-shell.io/aas/3/0/KeyTypes/Entity`
+.2+e|Entity | `\https://admin-shell.io/aas/3/1/KeyTypes/Entity`
 a|Entity
 
-.2+e|EventElement | `\https://admin-shell.io/aas/3/0/KeyTypes/EventElement`
+.2+e|EventElement | `\https://admin-shell.io/aas/3/1/KeyTypes/EventElement`
 a|
 Event
 
@@ -202,16 +202,16 @@ Note: event element is abstract.
 ====
 
 
-.2+e|File | `\https://admin-shell.io/aas/3/0/KeyTypes/File`
+.2+e|File | `\https://admin-shell.io/aas/3/1/KeyTypes/File`
 a|File
 
-.2+e|FragmentReference | `\https://admin-shell.io/aas/3/0/KeyTypes/FragmentReference`
+.2+e|FragmentReference | `\https://admin-shell.io/aas/3/1/KeyTypes/FragmentReference`
 a|Bookmark or a similar local identifier of a subordinate part of a primary resource
 
-.2+e|GlobalReference | `\https://admin-shell.io/aas/3/0/KeyTypes/GlobalReference`
+.2+e|GlobalReference | `\https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference`
 a|Global reference
 
-.2+e|Identifiable | `\https://admin-shell.io/aas/3/0/KeyTypes/Identifiable`
+.2+e|Identifiable | `\https://admin-shell.io/aas/3/1/KeyTypes/Identifiable`
 a|
 Identifiable
 
@@ -221,34 +221,34 @@ Note: identifiable is abstract, i.e. if a key uses "Identifiable" the reference 
 ====
 
 
-.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/0/KeyTypes/MultiLanguageProperty`
+.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/1/KeyTypes/MultiLanguageProperty`
 a|Property with a value that can be provided in multiple languages
 
-.2+e|Operation| `\https://admin-shell.io/aas/3/0/KeyTypes/Operation`
+.2+e|Operation| `\https://admin-shell.io/aas/3/1/KeyTypes/Operation`
 a|Operation
 
-.2+e|Property | `\https://admin-shell.io/aas/3/0/KeyTypes/Property`
+.2+e|Property | `\https://admin-shell.io/aas/3/1/KeyTypes/Property`
 a|Property
 
-.2+e|Range | `\https://admin-shell.io/aas/3/0/KeyTypes/Range`
+.2+e|Range | `\https://admin-shell.io/aas/3/1/KeyTypes/Range`
 a|Range with min and max
 
-.2+e|Referable | `\https://admin-shell.io/aas/3/0/KeyTypes/Referable`
+.2+e|Referable | `\https://admin-shell.io/aas/3/1/KeyTypes/Referable`
 a|
 ====
 Note: referables are abstract, i.e. if a key uses "Referable", the reference may be an Asset Administration Shell, a property, etc.
 ====
 
-.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/0/KeyTypes/ReferenceElement`
+.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/1/KeyTypes/ReferenceElement`
 a|Reference
 
-.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/0/KeyTypes/RelationshipElement`
+.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/1/KeyTypes/RelationshipElement`
 a|Relationship
 
-.2+e|Submodel | `\https://admin-shell.io/aas/3/0/KeyTypes/Submodel`
+.2+e|Submodel | `\https://admin-shell.io/aas/3/1/KeyTypes/Submodel`
 a|Submodel
 
-.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/0/KeyTypes/SubmodelElement`
+.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/1/KeyTypes/SubmodelElement`
 a|
 Submodel element
 
@@ -258,10 +258,10 @@ Note: submodel elements are abstract, i.e. if a key uses "SubmodelElement", the 
 ====
 
 
-.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/0/KeyTypes/SubmodelElementCollection`
+.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/1/KeyTypes/SubmodelElementCollection`
 a|Struct of submodel elements
 
-.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/0/KeyTypes/SubmodelElementList`
+.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/1/KeyTypes/SubmodelElementList`
 a|List of submodel elements
 |===
 
@@ -281,28 +281,28 @@ Note: not used as type but in constraints.
 
 
 h|Set of: |xref:AasReferableNonIdentifiables[AASReferableNonIdentifiables], xref:GenericFragmentKeys[GenericFragmentKeys]
-h|ID: | `\https://admin-shell.io/aas/3/0/FragmentKeys`  
+h|ID: | `\https://admin-shell.io/aas/3/1/FragmentKeys`  
 
 
 .2+h|Literal h| ID
    h|Explanation
 
 
-.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/0/FragmentKeys/AnnotatedRelationshipElement`
+.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/1/FragmentKeys/AnnotatedRelationshipElement`
 a|Annotated relationship element
 
 
-.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/0/FragmentKeys/BasicEventElement`
+.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/1/FragmentKeys/BasicEventElement`
 a|Basic event element
 
-.2+e|Blob | `\https://admin-shell.io/aas/3/0/FragmentKeys/Blob`
+.2+e|Blob | `\https://admin-shell.io/aas/3/1/FragmentKeys/Blob`
 a|Blob
 
-.2+e|Capability | `\https://admin-shell.io/aas/3/0/FragmentKeys/Capability`
+.2+e|Capability | `\https://admin-shell.io/aas/3/1/FragmentKeys/Capability`
 a|Capability
 
 
-.2+e|DataElement | `\https://admin-shell.io/aas/3/0/FragmentKeys/DataElement`
+.2+e|DataElement | `\https://admin-shell.io/aas/3/1/FragmentKeys/DataElement`
 a|
 Data Element
 
@@ -312,10 +312,10 @@ Note: data elements are abstract, i.e. if a key uses "DataElement", the referenc
 ====
 
 
-.2+e|Entity | `\https://admin-shell.io/aas/3/0/FragmentKeys/Entity`
+.2+e|Entity | `\https://admin-shell.io/aas/3/1/FragmentKeys/Entity`
 a|Entity
 
-.2+e|EventElement | `\https://admin-shell.io/aas/3/0/FragmentKeys/EventElement`
+.2+e|EventElement | `\https://admin-shell.io/aas/3/1/FragmentKeys/EventElement`
 a|
 Event
 
@@ -325,39 +325,39 @@ Note: event element is abstract.
 ====
 
 
-.2+e|File | `\https://admin-shell.io/aas/3/0/FragmentKeys/File`
+.2+e|File | `\https://admin-shell.io/aas/3/1/FragmentKeys/File`
 a|File
 
-.2+e|FragmentReference | `\https://admin-shell.io/aas/3/0/FragmentKeys/FragmentReference`
+.2+e|FragmentReference | `\https://admin-shell.io/aas/3/1/FragmentKeys/FragmentReference`
 a|Bookmark or a similar local identifier of a subordinate part of a primary resource
 
 
-.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/0/FragmentKeys/MultiLanguageProperty`
+.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/1/FragmentKeys/MultiLanguageProperty`
 a|Property with a value that can be provided in multiple languages
 
-.2+e|Operation| `\https://admin-shell.io/aas/3/0/FragmentKeys/Operation`
+.2+e|Operation| `\https://admin-shell.io/aas/3/1/FragmentKeys/Operation`
 a|Operation
 
-.2+e|Property | `\https://admin-shell.io/aas/3/0/FragmentKeys/Property`
+.2+e|Property | `\https://admin-shell.io/aas/3/1/FragmentKeys/Property`
 a|Property
 
-.2+e|Range | `\https://admin-shell.io/aas/3/0/FragmentKeys/Range`
+.2+e|Range | `\https://admin-shell.io/aas/3/1/FragmentKeys/Range`
 a|Range with min and max
 
-.2+e|Referable | `\https://admin-shell.io/aas/3/0/FragmentKeys/Referable`
+.2+e|Referable | `\https://admin-shell.io/aas/3/1/FragmentKeys/Referable`
 a|
 ====
 Note: referables are abstract, i.e. if a key uses "Referable", the reference may be an Asset Administration Shell, a property, etc.
 ====
 
-.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/0/FragmentKeys/ReferenceElement`
+.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/1/FragmentKeys/ReferenceElement`
 a|Reference
 
-.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/0/FragmentKeys/RelationshipElement`
+.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/1/FragmentKeys/RelationshipElement`
 a|Relationship
 
 
-.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/0/FragmentKeys/SubmodelElement`
+.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/1/FragmentKeys/SubmodelElement`
 a|
 Submodel element
 
@@ -367,10 +367,10 @@ Note: submodel elements are abstract, i.e. if a key uses "SubmodelElement", the 
 ====
 
 
-.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/0/FragmentKeys/SubmodelElementCollection`
+.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/1/FragmentKeys/SubmodelElementCollection`
 a|Struct of submodel elements
 
-.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/0/FragmentKeys/SubmodelElementList`
+.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/1/FragmentKeys/SubmodelElementList`
 a|List of submodel elements
 |===
 
@@ -390,27 +390,27 @@ Note: not used as type but in constraints.
 
 
 h|Set of: |xref:AasSubmodelElements[AasSubmodelElements]
-h|ID: | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables`  
+h|ID: | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables`  
 
 .2+h|Literal h| ID
    h|Explanation
 
 
-.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/AnnotatedRelationshipElement`
+.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/AnnotatedRelationshipElement`
 a|Annotated relationship element
 
 
-.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/BasicEventElement`
+.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/BasicEventElement`
 a|Basic event element
 
-.2+e|Blob | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Blob`
+.2+e|Blob | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Blob`
 a|Blob
 
-.2+e|Capability | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Capability`
+.2+e|Capability | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Capability`
 a|Capability
 
 
-.2+e|DataElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/DataElement`
+.2+e|DataElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/DataElement`
 a|
 Data Element
 
@@ -420,10 +420,10 @@ Note: data elements are abstract, i.e. if a key uses "DataElement", the referenc
 ====
 
 
-.2+e|Entity | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Entity`
+.2+e|Entity | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Entity`
 a|Entity
 
-.2+e|EventElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/EventElement`
+.2+e|EventElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/EventElement`
 a|
 Event
 
@@ -433,36 +433,36 @@ Note: event element is abstract.
 ====
 
 
-.2+e|File | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/File`
+.2+e|File | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/File`
 a|File
 
 
-.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/MultiLanguageProperty`
+.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/MultiLanguageProperty`
 a|Property with a value that can be provided in multiple languages
 
-.2+e|Operation| `\https://admin-shell.io/aas/3/0/AasSubmodelElements/Operation`
+.2+e|Operation| `\https://admin-shell.io/aas/3/1/AasSubmodelElements/Operation`
 a|Operation
 
-.2+e|Property | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Property`
+.2+e|Property | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Property`
 a|Property
 
-.2+e|Range | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Range`
+.2+e|Range | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Range`
 a|Range with min and max
 
-.2+e|Referable | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Referable`
+.2+e|Referable | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Referable`
 a|
 ====
 Note: referables are abstract, i.e. if a key uses "Referable", the reference may be an Asset Administration Shell, a property, etc.
 ====
 
-.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/ReferenceElement`
+.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/ReferenceElement`
 a|Reference
 
-.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/RelationshipElement`
+.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/RelationshipElement`
 a|Relationship
 
 
-.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/0/AAasReferableNonIdentifiables/SubmodelElement`
+.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/1/AAasReferableNonIdentifiables/SubmodelElement`
 a|
 Submodel element
 
@@ -472,10 +472,10 @@ Note: submodel elements are abstract, i.e. if a key uses "SubmodelElement", the 
 ====
 
 
-.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/SubmodelElementCollection`
+.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElementCollection`
 a|Struct of submodel elements
 
-.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/SubmodelElementList`
+.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElementList`
 a|List of submodel elements
 |===
 
@@ -493,21 +493,21 @@ h|ID: | `\https://admin-shell.io/aas/3/1/AasSubmodelElements`
    h|Explanation
 
 
-.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/AnnotatedRelationshipElement`
+.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/AnnotatedRelationshipElement`
 a|Annotated relationship element
 
 
-.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/BasicEventElement`
+.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/BasicEventElement`
 a|Basic event element
 
-.2+e|Blob | `\https://admin-shell.io/aas/3/0/AasSubmodelElements[/Blob`
+.2+e|Blob | `\https://admin-shell.io/aas/3/1/AasSubmodelElements[/Blob`
 a|Blob
 
-.2+e|Capability | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/Capability`
+.2+e|Capability | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/Capability`
 a|Capability
 
 
-.2+e|DataElement | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/DataElement`
+.2+e|DataElement | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/DataElement`
 a|
 Data Element
 
@@ -517,10 +517,10 @@ Note: data elements are abstract, i.e. if a key uses "DataElement", the referenc
 ====
 
 
-.2+e|Entity | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/Entity`
+.2+e|Entity | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/Entity`
 a|Entity
 
-.2+e|EventElement | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/EventElement`
+.2+e|EventElement | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/EventElement`
 a|
 Event
 
@@ -530,32 +530,32 @@ Note: event element is abstract.
 ====
 
 
-.2+e|File | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/File`
+.2+e|File | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/File`
 a|File
 
 
-.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/MultiLanguageProperty`
+.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/MultiLanguageProperty`
 a|Property with a value that can be provided in multiple languages
 
-.2+e|Operation| `\https://admin-shell.io/aas/3/0/AasSubmodelElements/Operation`
+.2+e|Operation| `\https://admin-shell.io/aas/3/1/AasSubmodelElements/Operation`
 a|Operation
 
-.2+e|Property | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/Property`
+.2+e|Property | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/Property`
 a|Property
 
-.2+e|Range | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/Range`
+.2+e|Range | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/Range`
 a|Range with min and max
 
 
 
-.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/ReferenceElement`
+.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/ReferenceElement`
 a|Reference
 
-.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/RelationshipElement`
+.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/RelationshipElement`
 a|Relationship
 
 
-.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElement`
+.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/SubmodelElement`
 a|
 Submodel element
 
@@ -565,10 +565,10 @@ Note: submodel elements are abstract, i.e. if a key uses "SubmodelElement", the 
 ====
 
 
-.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementCollection`
+.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/SubmodelElementCollection`
 a|Struct of submodel elements
 
-.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementList`
+.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/1/AasSubmodelElements/SubmodelElementList`
 a|List of submodel elements
 |===
 
@@ -588,30 +588,30 @@ Note: not used as type but in constraints.
 
 
 h|Set of: |xref:AasReferableNonIdentifiables[AASReferableNonIdentifiables], xref:AasIdentifiables[AasIdentifiables]
-h|ID: | `\https://admin-shell.io/aas/3/0/AasReferables`  
+h|ID: | `\https://admin-shell.io/aas/3/1/AasReferables`  
 
 .2+h|Literal h| ID
    h|Explanation
 
 
-.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/AnnotatedRelationshipElement`
+.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/AnnotatedRelationshipElement`
 a|Annotated relationship element
 
-.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/AssetAdministrationShell`
+.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/AssetAdministrationShell`
 a|Asset Administration Shell
 
-.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/BasicEventElement`
+.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/BasicEventElement`
 a|Basic event element
 
-.2+e|Blob | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Blob`
+.2+e|Blob | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Blob`
 a|Blob
 
-.2+e|Capability | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Capability`
+.2+e|Capability | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Capability`
 a|Capability
 
 
 
-.2+e|DataElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/DataElement`
+.2+e|DataElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/DataElement`
 a|
 Data Element
 
@@ -621,10 +621,10 @@ Note: data elements are abstract, i.e. if a key uses "DataElement", the referenc
 ====
 
 
-.2+e|Entity | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Entity`
+.2+e|Entity | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Entity`
 a|Entity
 
-.2+e|EventElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/EventElement`
+.2+e|EventElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/EventElement`
 a|
 Event
 
@@ -634,39 +634,39 @@ Note: event element is abstract.
 ====
 
 
-.2+e|File | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/File`
+.2+e|File | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/File`
 a|File
 
 
 
 
 
-.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/MultiLanguageProperty`
+.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/MultiLanguageProperty`
 a|Property with a value that can be provided in multiple languages
 
-.2+e|Operation| `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Operation`
+.2+e|Operation| `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Operation`
 a|Operation
 
-.2+e|Property | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Property`
+.2+e|Property | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Property`
 a|Property
 
-.2+e|Range | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Range`
+.2+e|Range | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Range`
 a|Range with min and max
 
-.2+e|Referable | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/Referable`
+.2+e|Referable | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Referable`
 a|
 ====
 Note: referables are abstract, i.e. if a key uses "Referable", the reference may be an Asset Administration Shell, a property, etc.
 ====
 
-.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/ReferenceElement`
+.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/ReferenceElement`
 a|Reference
 
-.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/RelationshipElement`
+.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/RelationshipElement`
 a|Relationship
 
 
-.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/SubmodelElement`
+.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElement`
 a|
 Submodel element
 
@@ -676,10 +676,10 @@ Note: submodel elements are abstract, i.e. if a key uses "SubmodelElement", the 
 ====
 
 
-.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/SubmodelElementCollection`
+.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElementCollection`
 a|Struct of submodel elements
 
-.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/0/AasReferableNonIdentifiables/SubmodelElementList`
+.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElementList`
 a|List of submodel elements
 |===
 
@@ -699,12 +699,12 @@ Note: not used as type but in constraints.
 
 
 |Set of: |--
-h|ID: | `\https://admin-shell.io/aas/3/0/GenericFragmentKeys`  
+h|ID: | `\https://admin-shell.io/aas/3/1/GenericFragmentKeys`  
 
 .2+h|Literal h| ID
    h|Explanation
    
-.2+e|FragmentReference | `\https://admin-shell.io/aas/3/0/GenericFragmentKeys/FragmentReference`
+.2+e|FragmentReference | `\https://admin-shell.io/aas/3/1/GenericFragmentKeys/FragmentReference`
 a|Bookmark or a similar local identifier of a subordinate part of a primary resource
 
 |===
@@ -725,18 +725,18 @@ Note: not used as type but in constraints.
 
 
 h|Set of: |--
-h|ID: | `\https://admin-shell.io/aas/3/0/AasIdentifiables`  
+h|ID: | `\https://admin-shell.io/aas/3/1/AasIdentifiables`  
 
 .2+h|Literal h| ID
    h|Explanation
    
-.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/0/AasIdentifiables/AssetAdministrationShell` 
+.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/1/AasIdentifiables/AssetAdministrationShell` 
 a|Asset Administration Shell
 
-.2+e|ConceptDescription | `\https://admin-shell.io/aas/3/0/AasIdentifiables/ConceptDescription` 
+.2+e|ConceptDescription | `\https://admin-shell.io/aas/3/1/AasIdentifiables/ConceptDescription` 
 a|Concept description
 
-.2+e|Identifiable | `\https://admin-shell.io/aas/3/0/AasIdentifiables/Identifiable` 
+.2+e|Identifiable | `\https://admin-shell.io/aas/3/1/AasIdentifiables/Identifiable` 
 a|
 Identifiable
 
@@ -759,12 +759,12 @@ a|Submodel
 h|Enumeration: e|[[GenericGloballyIdentifiables]]GenericGloballyIdentifiables
 h|Explanation: a|Enumeration of different key value types within a key
 h|Set of: |--
-h|ID: | `\https://admin-shell.io/aas/3/0/GenericGloballyIdentifiables`  
+h|ID: | `\https://admin-shell.io/aas/3/1/GenericGloballyIdentifiables`  
 
 .2+h|Literal h| ID
    h|Explanation
    
-.2+e|GlobalReference | `\https://admin-shell.io/aas/3/0/GenericGloballyIdentifiables/GlobalReference` 
+.2+e|GlobalReference | `\https://admin-shell.io/aas/3/1/GenericGloballyIdentifiables/GlobalReference` 
 a|Global reference
 
 |===


### PR DESCRIPTION
Decison to use indivual versioning for classes and attributes was 
revised. Therefore change  /3/0 to /3/1 semanticId for metamodel 
elements

+ upate changelog
Close #376 