### PR TITLE
Add Explanation of RegEx and Reason for AASd-130

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -70,4 +70,27 @@ Note: The semanticId of a SpecificAssetId with the predefined name "gloablAssetI
 
 {aasd130}
 
+An attribute with data type "string" shall consist of these characters only:
+The string contains only valid Unicode characters encoded in UTF-16 format
+The string can include common characters like tabs, newlines, carriage returns, and spaces.
+It allows a broad range of Unicode characters, including those beyond the Basic Multilingual Plane (BMP) which are represented using surrogate pairs in UTF-16 encoding.
+It ensures that the entire string adheres to the rules of UTF-16 encoding, which is a standard way of representing a wide range of characters from different languages.
+
+This lead to te resulting RegEx:
+
+^: Asserts the start of the string.
+[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]: Defines a character class that allows various Unicode characters.
+
+\x09: ASCII horizontal tab.
+\x0A: ASCII linefeed (newline).
+\x0D: ASCII carriage return.
+\x20: ASCII space.
+-: Represents a range.
+\uD7FF: The upper limit of the Basic Multilingual Plane (BMP) in UTF-16.
+\uE000-\uFFFD: Represents the range of characters from the start of the supplementary planes up to the last valid Unicode character (excluding surrogate pairs).
+\u00010000-\u0010FFFF: Represents the range of valid surrogate pairs used for characters beyond the BMP.
+*: Allows for zero or more occurrences of the characters within the character class.
+
+$: Asserts the end of the string.
+
 Constraint AASd-130 ensures that encoding and interoperability between different serializations is possible. It corresponds to the restrictions as defined for the XML Schema 1.0footnote:[https://www.w3.org/TR/xml/#charsets].

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -81,7 +81,7 @@ The character set of XML includes (given as numerical code points and/or ranges 
 * 0x0A: ASCII linefeed (newline),
 * 0x0D: ASCII carriage return.
 * 0x20: ASCII space,
-* 0x20 - 0xD7FF: all the characters above space in the Basic Multilingual Plane, and
+* 0x20 - 0xD7FF: all the characters of the Basic Multilingual Plane, and
 * 0x00010000-0x0010FFFF: all the characters beyond the Basic Multilingual Plane (*e.g.*, emoticons).
 The string can include common characters like tabs, newlines, carriage returns, and spaces.
 It allows a broad range of Unicode characters, including those beyond the Basic Multilingual Plane (BMP) which are represented using surrogate pairs in UTF-16 encoding.

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -70,7 +70,16 @@ Note: The semanticId of a SpecificAssetId with the predefined name "gloablAssetI
 
 {aasd130}
 
-An attribute with data type "string" shall consist of these characters only:
+We have to restrict an attribute with data type "string" to the characters which are representable in XML.
+Otherwise, strings in other formats such as JSON could not be converted to XML.
+
+The character set of XML includes (given as numerical code points and/or ranges in Unicode):
+* 0x09: ASCII horizontal tab,
+* 0x0A: ASCII linefeed (newline),
+* 0x0D: ASCII carriage return.
+* 0x20: ASCII space,
+* 0x20 - 0xD7FF: all the characters above space in the Basic Multilingual Plane, and
+* 0x00010000-0x0010FFFF: all the characters beyond the Basic Multilingual Plane (*e.g.*, emoticons).
 The string can include common characters like tabs, newlines, carriage returns, and spaces.
 It allows a broad range of Unicode characters, including those beyond the Basic Multilingual Plane (BMP) which are represented using surrogate pairs in UTF-16 encoding.
 It ensures that the entire string adheres to the rules of UTF-16 encoding, which is a standard way of representing a wide range of characters from different languages.

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -83,9 +83,6 @@ The character set of XML includes (given as numerical code points and/or ranges 
 * 0x20: ASCII space,
 * 0x20 - 0xD7FF: all the characters of the Basic Multilingual Plane, and
 * 0x00010000-0x0010FFFF: all the characters beyond the Basic Multilingual Plane (*e.g.*, emoticons).
-The string can include common characters like tabs, newlines, carriage returns, and spaces.
-It allows a broad range of Unicode characters, including those beyond the Basic Multilingual Plane (BMP) which are represented using surrogate pairs in UTF-16 encoding.
-It ensures that the entire string adheres to the rules of UTF-16 encoding, which is a standard way of representing a wide range of characters from different languages.
 
 This leads to the following regular expression:
 ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]$

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -85,7 +85,9 @@ It allows a broad range of Unicode characters, including those beyond the Basic 
 It ensures that the entire string adheres to the rules of UTF-16 encoding, which is a standard way of representing a wide range of characters from different languages.
 
 This lead to te resulting RegEx:
+^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]$
 
+Where:
 ^: Asserts the start of the string.
 [\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]: Defines a character class that allows various Unicode characters.
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -70,9 +70,12 @@ Note: The semanticId of a SpecificAssetId with the predefined name "gloablAssetI
 
 {aasd130}
 
-We have to restrict an attribute with data type "string" to the characters which are representable in XML.
+Constraint AASd-130 ensures that encoding and interoperability between different serializations is possible. It corresponds to the restrictions as defined for the XML Schema 1.0footnote:[https://www.w3.org/TR/xml/#charsets].
+
+Therefore, we need to restrict an attribute of data type 'string' to the characters that can be represented in any exchange format and language.
 Otherwise, strings in other formats such as JSON could not be converted to XML.
 
+The string contains only valid Unicode characters in the range of encoded in UTF-16 format
 The character set of XML includes (given as numerical code points and/or ranges in Unicode):
 * 0x09: ASCII horizontal tab,
 * 0x0A: ASCII linefeed (newline),
@@ -102,5 +105,3 @@ Where:
 *: Allows for zero or more occurrences of the characters within the character class.
 
 $: Asserts the end of the string.
-
-Constraint AASd-130 ensures that encoding and interoperability between different serializations is possible. It corresponds to the restrictions as defined for the XML Schema 1.0footnote:[https://www.w3.org/TR/xml/#charsets].

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -85,7 +85,7 @@ The character set of XML includes (given as numerical code points and/or ranges 
 * 0x00010000-0x0010FFFF: all the characters beyond the Basic Multilingual Plane (*e.g.*, emoticons).
 
 This leads to the following regular expression:
-^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]$
+^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]*$
 
 Where:
 ^: Asserts the start of the string.

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -71,7 +71,6 @@ Note: The semanticId of a SpecificAssetId with the predefined name "gloablAssetI
 {aasd130}
 
 An attribute with data type "string" shall consist of these characters only:
-The string contains only valid Unicode characters encoded in UTF-16 format
 The string can include common characters like tabs, newlines, carriage returns, and spaces.
 It allows a broad range of Unicode characters, including those beyond the Basic Multilingual Plane (BMP) which are represented using surrogate pairs in UTF-16 encoding.
 It ensures that the entire string adheres to the rules of UTF-16 encoding, which is a standard way of representing a wide range of characters from different languages.

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -92,7 +92,7 @@ This leads to the following regular expression:
 
 Where:
 ^: Asserts the start of the string.
-[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]: Defines a character class that allows various Unicode characters.
+[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]: Defines a character class that allows various Unicode characters, with the following elements:
 
 \x09: ASCII horizontal tab.
 \x0A: ASCII linefeed (newline).

--- a/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/Spec/IDTA-01001_Metamodel_Constraints.adoc
@@ -84,7 +84,7 @@ The string can include common characters like tabs, newlines, carriage returns, 
 It allows a broad range of Unicode characters, including those beyond the Basic Multilingual Plane (BMP) which are represented using surrogate pairs in UTF-16 encoding.
 It ensures that the entire string adheres to the rules of UTF-16 encoding, which is a standard way of representing a wide range of characters from different languages.
 
-This lead to te resulting RegEx:
+This leads to the following regular expression:
 ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u00010000-\u0010FFFF]$
 
 Where:


### PR DESCRIPTION
This was necessary because there was a broad disagreement in different 
committees and persons about what the AASd-130 constraint says, what 
the RegEx in AASd-130 means and what the reason for the definition of 
the constraint was.