### PR TITLE
Implement Minor Fixes and Editorial Changes

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/backus-naur-form.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/backus-naur-form.adoc
@@ -46,7 +46,7 @@ where:
 
 <e-mail-Addresses> ::= {<e-mail-Address>}*
 
-<e-mail-Addresse> ::= <local-part> "@" <domain>
+<e-mail-Address> ::= <local-part> "@" <domain>
 
 <name> ::= characters
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/concepts-aas.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/concepts-aas.adoc
@@ -65,7 +65,7 @@ As far as the large variety of assets in Industry 4.0 are concerned, the Asset A
 This reduces complexity and allows for scalability.
 Additional motivation can be found in xref:bibliography.adoc#bib2[[2\]] xref:bibliography.adoc#bib4[[4\]] xref:bibliography.adoc#bib7[[7\]] xref:bibliography.adoc#bib8[[8\]].
 
-.Important Concepts of Industry 4.0 attached to the Asset xref:Bibliography.adoc#bib2[[2\]] xref:Bibliography.adoc#bib21[[21\]]
+.Important Concepts of Industry 4.0 attached to the Asset xref:bibliography.adoc#bib2[[2\]] xref:bibliography.adoc#bib21[[21\]]
 image::image60.jpeg[]
 
 == The Concept of Properties

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/metamodel-with-inheritance.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/metamodel-with-inheritance.adoc
@@ -22,13 +22,6 @@ In this annex, some UML diagrams are shown together with all attributes inherite
 include::partial$diagrams/89-asset-administration-shell.puml[]
 ....
 
-
-====
-Note: abstract classes are numbered h0_, h1_ etc.
-Their aliases however are defined without this prefix.
-The reason for this naming is that no order for inherited classes can be defined in the tooling used for UML modelling (Enterprise Architect); they are ordered alphabetically.
-====
-
 .Model for Submodel Elements with Inherited Attributes
 [plantuml, 90-submodel-element, svg]
 ....

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/nav_annex.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/nav_annex.adoc
@@ -30,5 +30,5 @@ SPDX-License-Identifier: CC-BY-4.0
 
 * xref:Annex/ChangeLog.adoc[Change Log]
 
-* xref:Annex/Bibliography.adoc[Bibliography]
+* xref:Annex/bibliography.adoc[Bibliography]
 ////

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/uml.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/uml.adoc
@@ -26,7 +26,7 @@ Navigability notation was often used in the past according to an informal conven
 This convention is now deprecated.
 Aggregation type, navigability, and end ownership are separate concepts, each with their own explicit notation.
 Association ends owned by classes are always navigable, while those owned by associations may be navigable or not."
-xref:Bibliography.adoc#bib35[[35\]]]
+xref:bibliography.adoc#bib35[[35\]]]
 
 .Class
 [[image-64-class]]

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/uml.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/uml.adoc
@@ -219,7 +219,6 @@ It contains two literal values, "a" and "b".
 It is a class with stereotype \<<enumeration>>.
 The literals owned by the enumeration are ordered.
 
-footnote:[In Enterprise Architect, the single enumeration values also have a stereotype \<<enum>> each.]
 [[image-76-enumeration]]
 [plantuml, 76-enumeration, svg]
 ....

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/uml.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/uml.adoc
@@ -219,7 +219,7 @@ It contains two literal values, "a" and "b".
 It is a class with stereotype \<<enumeration>>.
 The literals owned by the enumeration are ordered.
 
-.Enumerationfootnote:[In Enterprise Architect, the single enumeration values also have a stereotype \<<enum>> each.]
+footnote:[In Enterprise Architect, the single enumeration values also have a stereotype \<<enum>> each.]
 [[image-76-enumeration]]
 [plantuml, 76-enumeration, svg]
 ....

--- a/documentation/IDTA-01001/modules/ROOT/pages/bibliography.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/bibliography.adoc
@@ -166,10 +166,10 @@ Industrial Digital Twin Association.
 November 2022. [Online] Available: https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2022/12/2022-12-07_IDTA_AAS-Reading-Guide.pdf
 
 [#bib39]
-[39] IDTA-02003 "Submodel Template of the Asset Administration Shell - Generic Frame for Technical Data for Industrial Equipment in Manufacturing", Version 1.2, Aug. 2022, Industrial Digital Twin Assocation [Online] Available: https://industrialdigitaltwin.org/en/content-hub/submodels
+[39] IDTA-02003 "Submodel Template of the Asset Administration Shell - Generic Frame for Technical Data for Industrial Equipment in Manufacturing", Version 1.2, Aug. 2022, Industrial Digital Twin Association [Online] Available: https://industrialdigitaltwin.org/en/content-hub/submodels
 
 [#bib40]
-[40] IDTA-02006 "Submodel Template of the Asset Administration Shell - Digital Nameplate for Industrial Equipment", Version 2.0, Oct. 2022, Industrial Digital Twin Assocation [Online] Available: https://industrialdigitaltwin.org/en/content-hub/submodels
+[40] IDTA-02006 "Submodel Template of the Asset Administration Shell - Digital Nameplate for Industrial Equipment", Version 2.0, Oct. 2022, Industrial Digital Twin Association [Online] Available: https://industrialdigitaltwin.org/en/content-hub/submodels
 
 ////
 [#bib41]
@@ -224,6 +224,6 @@ Oct. 2020, Plattform Industrie 4.0 [Online] Available: https://www.plattform-i40
 [#bib51]
 [51] "AAS Repository.
 Repository for Information and Code for the Asset Administration Shell".
-Industrial Digital Twin Assocation. https://github.com/admin-shell-io
+Industrial Digital Twin Association. https://github.com/admin-shell-io
 
 // bib52 see [41]

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -308,7 +308,7 @@ Note: Security is still part of the Asset Administration Shell, but the Asset Ad
 |{empty} |xref:spec-metamodel/core.adoc#AssetKind[AssetKind/Type] |Updated description of value "Type" of enumeration "AssetKind" conformant to IEC 63278-1
 |x |xref:spec-metamodel/submodel-elements.adoc#BasicEventElement[BasicEvent] |Renamed to BasicEventElement and set to \<<Experimental>>
 
-|xxref:Bibliography.adoc#bib2[[2\]] |xref:spec-metamodel/datatypes.adoc#BlobType[BlobType] |Primitive changed from "group of bytes" to Base64Binary
+|xxref:bibliography.adoc#bib2[[2\]] |xref:spec-metamodel/datatypes.adoc#BlobType[BlobType] |Primitive changed from "group of bytes" to Base64Binary
 
 |x |ConceptDictionary |Removed
 |x |Constraint |Abstract class removed. Formula now used in Security part only
@@ -394,7 +394,7 @@ Now part of AasSubmodelElements
 |x |ReferenceTypes/GlobalReference |Renamed to ExternalReference
 |{empty} |RelationshipElement/first |Type changes from model reference Referable to Reference (global or model reference)
 |{empty} |RelationshipElement/second |Type changes from model reference Referable to Reference (global or model reference)
-|xxref:Bibliography.adoc#bib1[[1\]] |SubmodelElement/kind |Removed. SubmodelElement no longer inherits from HasKind
+|xxref:bibliography.adoc#bib1[[1\]] |SubmodelElement/kind |Removed. SubmodelElement no longer inherits from HasKind
 |{empty} |xref:spec-metamodel/datatypes.adoc#ValueDataType[ValueDataType] |Before as specified via DataTypeDef, now any xsd atomic type as specified via DataTypeDefXsd
 |{empty}x |View |Removed
 |===

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -71,7 +71,8 @@ Major Changes:
 ** add chapter for Submodel Example (with properties from SMT Technical Data, not Families any longer)
 ** update Schema for JSON-Value Serialization (https://github.com/admin-shell-io/aas-specs/issues/366[#366])
 * update explanatory text and notes in the context of AdministrativeInformation (https://github.com/admin-shell-io/aas-specs/issues/331[#331])
-* Transfer from .docx to asciidoc (.adoc) and maintenance in github
+* Transfer from .docx to asciidoc (.adoc) and maintenance in GitHub
+* Transfer of all UML figures to PlantUML (.puml) and maintenance in GitHub
 
 Minor Changes:
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -80,7 +80,7 @@ Minor Changes:
 * update information on OPC UA mapping (https://github.com/admin-shell-io/aas-specs/issues/373[#373])
 * update information on AutomationML mapping (https://github.com/admin-shell-io/aas-specs/issues/397[#397])
 * update bibliography (newer versions, link update, removal of entries not referenced)
-* consistent usage of idShortPaht and IRDI-Path (https://github.com/admin-shell-io/aas-specs/issues/385)
+* consistent usage of idShortPath and IRDI-Path (https://github.com/admin-shell-io/aas-specs/issues/385)
 * editorial changes
 
 
@@ -816,7 +816,7 @@ Constraint AASd-051: A _ConceptDescription_ shall have one of the following cate
 === Metamodel Changes V3.0RC02 vs. V2.0.1 w/o Security Part
 
 ====
-Note: if you already implemented the changes made in V3.0RC01, please refer to the corresponding clause in the this annex.
+Note: if you already implemented the changes made in V3.0RC01, please refer to the corresponding clause in the annex.
 This annex is for readers familiar with V2.0.x only.
 ====
 
@@ -1112,7 +1112,7 @@ Constraint AASd-090: For data elements category (inherited by Referable) shall b
 | |AASd-100 |New |Constraint AASd-100: An attribute with data type "string" is not allowed to be empty.
 | |AASd-107 |New |Constraint AASd-107: If a first level child element in a SubmodelElementList has a semanticId it shall be identical to SubmodelElementList/semanticIdListElement.
 | |AASd-108 |New |Constraint AASd-108: All first level child elements in a SubmodelElementList shall have the same submodel element type as specified in SubmodelElementList/typeValueListElement.
-| |AASd-109 |New |Constraint AASd-109: If SubmodelElementList/typeValueListElement equal to Property or Range SubmodelElementList/valueTypeListElement shall be set and all first level child elements in the SubmodelElementList shall have the the value type as specified in SubmodelElementList/valueTypeListElement.
+| |AASd-109 |New |Constraint AASd-109: If SubmodelElementList/typeValueListElement equal to Property or Range SubmodelElementList/valueTypeListElement shall be set and all first level child elements in the SubmodelElementList shall have the value type as specified in SubmodelElementList/valueTypeListElement.
 | |AASd-114 |New |Constraint AASd-114: If two first level child elements in a SubmodelElementList have a semanticId then they shall be identical.
 | |AASd-115 |New |Constraint AASd-115: If a first level child element in a SubmodelElementList does not specify a semanticId then the value is assumed to be identical to SubmodelElementList/semanticIdListElement.
 | |AASd-116 |New |Constraint AASd-116: "globalAssetId" (case-insensitive) is a reserved key. If used as value for SpecificAssetId/name IdentifierKeyValuePair/value shall be identical to AssetInformation/globalAssetId.
@@ -1155,7 +1155,7 @@ Constraint AASD-120: idShort of submodel elements within a SubmodelElementList s
 | |xref:data-specifications.adoc#DataSpecification[DataSpecification] a|
 Stereotype \<<Template>> added + does not inherit from Identifiable any longer because Data Specification are handled in a different way
 
-Some attributes are added to DataSpecification as new attributes like id, administration and description.(see separate entries)
+Some attributes are added to DataSpecification as new attributes like id, administration and description (see separate entries).
 
 | |DataSpecification/category |Removed, was inherited before by Identifiable
 | |DataSpecification/displayName |Removed, was inherited before by Identifiable

--- a/documentation/IDTA-01001/modules/ROOT/pages/general.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/general.adoc
@@ -259,7 +259,7 @@ Identification will take place for two purposes
 In the domain of smart manufacturing, the assets need to be uniquely identified worldwide xref:bibliography.adoc#bib4[[4\]] xref:bibliography.adoc#bib20[[20\]] by the means of identifiers (IDs).
 The Administration Shell also has a unique ID (see Figure <<image-unique-identifier-for-aas-and-asset>>).
 
-.Unique Identifier for Administration Shell and Asset (Modified Figure from xref:Bibliography.adoc#bib4[[4\]])
+.Unique Identifier for Administration Shell and Asset (Modified Figure from xref:bibliography.adoc#bib4[[4\]])
 [[image-unique-identifier-for-aas-and-asset]]
 image::image6.jpeg[]
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/includes/idshortpath.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/includes/idshortpath.adoc
@@ -12,7 +12,7 @@ Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, d
 
 === Format "Path" (idShortPath Serialization) in JSON
 
-To get only the idShort paths of a submodel element hierarchy, the serialization format is specified in terms of an idShortPath notation to be returned in an JSON array.
+To get only the idShortPaths of a submodel element hierarchy, the serialization format is specified in terms of an idShortPath notation to be returned in an JSON array.
 The notation differs depending on whether a SubmodelElementCollection or a SubmodelElementList is present.
 In the first case, the submodel element's idShort is separated by "." (dot) from top level down to child level.
 In the second case, square brackets with an index "[<Index>]" are appended after the idShort of the containing SubmodelElementList.
@@ -32,7 +32,7 @@ In any case, the first item of any idShortPath is the idShort of the requested e
 <NonZeroDigit>  ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 ....
 
-In the following example, where a request for idShort paths targets a  _MySubmodelElementCollection_ with SerializationModifier level = deep, the list of idShort paths is returned as follows:
+In the following example, where a request for idShortPaths targets a  _MySubmodelElementCollection_ with SerializationModifier level = deep, the list of idShortPaths is returned as follows:
 
 ====
 EXAMPLE Submodel

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
@@ -590,7 +590,7 @@ include::partial$diagrams/23-referable.puml[]
 The metamodel differentiates between elements that are identifiable, referable, or none of both.
 The latter means they are neither inheriting from _Referable_ nor from _Identifiable_, which applies e.g. to __Qualifier__s.
 
-Referable elements can be referenced via the _idShort_ (with the exception of elements within a xref:spec-metamodel/submodel-elements.adoc#submodel-element-list-attributes [SubmodelElementList]).
+Referable elements can be referenced via the _idShort_ (except for elements within a xref:spec-metamodel/submodel-elements.adoc#submodel-element-list-attributes [SubmodelElementList]).
 For details on referencing, see Clause xref:spec-metamodel/referencing.adoc[Referencing in Asset Administration Shells].
 
 Not every element of the metamodel is referable.

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/core.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/core.adoc
@@ -265,7 +265,7 @@ h|Explanation: 3+a|
 A submodel defines a specific aspect of the asset represented by the Asset Administration Shell.
 
 A submodel is used to structure the digital representation and technical functionality of an Administration Shell into distinguishable parts.
-Each submodel refers to a well-defined domain or subject matter.
+Each submodel refers to a well-defined domain or subject.
 Submodels can become standardized and, in turn, submodel templates.
 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/core.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/core.adoc
@@ -188,7 +188,7 @@ a|Neither a type asset nor an instance asset nor a role asset
 
 |===
 
-For more information on types and instances, see Clause xref:general.html#types-and-instances[Types and Instances].
+For more information on types and instances, see Clause xref:general.adoc#types-and-instances[Types and Instances].
 
 [.table-with-appendix-table]
 [cols="25%,40%,25%,10%"]

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/overview.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/overview.adoc
@@ -93,12 +93,6 @@ Elements from package "Types" are specified in Clause xref:spec-metamodel/dataty
 The only package that is not listed is "Data Specifications (Templates)" because data specifications are handled differently.
 Data specification templates are explained in Clause ref:data-specifications.adoc[Data Specification Templates].
 
-====
-Note: the abstract classes are numbered h0_, h1_, etc. (e.g. h1_Referable); their aliases however are defined without this prefix.
-The reason for this naming is that no order for inherited classes can be defined in the tooling used for UML modelling (Enterprise Architect), since they are ordered alphabetically.
-The order is important for some serializations (e.g. for XML).
-====
-
 .Metamodel Package Overview
 [[image-metamodel-package-overview]]
 [plantuml, 13-structure, svg]

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/referencing.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/referencing.adoc
@@ -21,7 +21,7 @@ To date, two kinds of references are distinguished: references to external objec
 Model references are also used for metamodel inherent relationships like submodels of an Asset Administration Shell (notation see Annex A).
 
 An external reference is a unique identifier.
-The identifier can be a concatenation of different identifiers, representing e.g. an IRDI path.
+The identifier can be a concatenation of different identifiers, representing e.g. an IRDI-Path.
 
 ====
 Note: references should not be mixed up with locators.

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/submodel-elements.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/submodel-elements.adoc
@@ -826,7 +826,7 @@ Note: there is no _idShort_ for submodel elements in lists (see Constraint AASd-
 ====
 
 Submodel element lists are also used to create multidimensional arrays.
-A two-dimensional array listxref:Bibliography.adoc#bib3[[3\]]xref:bibliography.adoc#bib5[[5\]] with _Property_ values would be realized like follows: the first submodel element list would contain three _SubmodelElementList_ elements.
+A two-dimensional array listxref:bibliography.adoc#bib3[[3\]]xref:bibliography.adoc#bib5[[5\]] with _Property_ values would be realized like follows: the first submodel element list would contain three _SubmodelElementList_ elements.
 Each of these three _SubmodelElementLists_ would contain 5 single _Property_ elements.
 The _semanticId_ of the contained properties would be the same for all lists in the first list, i.e. _semanticIdListElement_ would be identical for all three lists contained in the first list.
 The _semanticId_ of the three contained lists would differ depending on the dimension it represents.

--- a/documentation/IDTA-01001/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
@@ -328,7 +328,7 @@ Note 1 to entry: can consist of single elements, which are also known as functio
 ====
 
 
-_[SOURCE: according to xref:Bibliography.adoc#bib18[[18\]]]_
+_[SOURCE: according to xref:bibliography.adoc#bib18[[18\]]]_
 ////
 
 *template*::

--- a/documentation/IDTA-01001/modules/ROOT/partials/diagrams/11-asset-administration-shell.puml
+++ b/documentation/IDTA-01001/modules/ROOT/partials/diagrams/11-asset-administration-shell.puml
@@ -1,7 +1,7 @@
 @startuml
 !theme idta from https://raw.githubusercontent.com/admin-shell-io/aas-specs-antora/main/plantuml/
 
-!include https://raw.githubusercontent.com/admin-shell-io/aas-specs/IDTA-01001-3-1_working/documentation/IDTA-01001/modules/ROOT/partials/diagrams/classes/administrative-information.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs/IDTA-01001-3-1_working/documentation/IDTA-01001/modules/ROOT/partials/diagrams/classes/asset-administration-shell.puml
 !include https://raw.githubusercontent.com/admin-shell-io/aas-specs/IDTA-01001-3-1_working/documentation/IDTA-01001/modules/ROOT/partials/diagrams/classes/asset-information.puml
 !include https://raw.githubusercontent.com/admin-shell-io/aas-specs/IDTA-01001-3-1_working/documentation/IDTA-01001/modules/ROOT/partials/diagrams/classes/enum-asset-kind.puml
 !include https://raw.githubusercontent.com/admin-shell-io/aas-specs/IDTA-01001-3-1_working/documentation/IDTA-01001/modules/ROOT/partials/diagrams/classes/specific-asset-id.puml

--- a/documentation/IDTA-01001/modules/ROOT/partials/diagrams/uml-basics/71-default-value.puml
+++ b/documentation/IDTA-01001/modules/ROOT/partials/diagrams/uml-basics/71-default-value.puml
@@ -2,8 +2,8 @@
 !theme idta from https://raw.githubusercontent.com/admin-shell-io/aas-specs-antora/main/plantuml/
 
 class Class1 {
-  +attr1: Integer = 5
-  +attr2: String = "str"
-  +attr3: Boolean = true
+  +attr1: integer = 5
+  +attr2: string = "str"
+  +attr3: boolean = true
 }
 @enduml


### PR DESCRIPTION
- Fix an AAS puml diagramm
- Use "IRDI-Path" instead of "IRDI path". See #385 
- Use "idShortPaths" instead of "idShort paths". See #385 
- Fix some typos and grammar
- Fix unresolved refs
- Add use of PlantUML to changelog
- Remove mentions of Enterprise Architect