### PR TITLE
fix bugs in Clause Referencing

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/referencing.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/referencing.adoc
@@ -116,15 +116,7 @@ include::partial$diagrams/49-key.puml[]
 
 Keys are used to define references (xref:spec-metamodel/referencing.adoc#Reference[Reference]).
 
-<<model-for-refs-keys>> presents a logical model of key types.
-These logical enumerations are used to formulate constraints.
 
-[#model-for-refs-keys]
-.Logical Model for Keys of References (non-normative)
-[plantuml, 50-key, svg]
-....
-include::partial$diagrams/50-key.puml[]
-....
 
 
 .Metamodel of KeyTypes Enumeration
@@ -393,6 +385,19 @@ a|List of submodel elements
 
 {empty} +
 
+== Logical Enumerations 
+
+<<model-for-refs-keys>> presents a logical model of key types.
+These logical enumerations may be used to formulate constraints.
+
+[#model-for-refs-keys]
+.Logical Model for Keys of References (non-normative)
+[plantuml, 50-key, svg]
+....
+include::partial$diagrams/50-key.puml[]
+....
+
+
 [.table-with-appendix-table]
 [cols="30%h,70%"]
 |===
@@ -584,7 +589,11 @@ a|Struct of submodel elements
 a|List of submodel elements
 |===
 
+
+
 {empty} +
+
+
 
 [.table-with-appendix-table]
 [cols="30%h,70%"]
@@ -606,26 +615,28 @@ h|ID: | `\https://admin-shell.io/aas/3/1/AasReferables`
 h|Explanation
 
 
-.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/AnnotatedRelationshipElement`
+.2+e|AnnotatedRelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferables/AnnotatedRelationshipElement`
 a|Annotated relationship element
 
-.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/AssetAdministrationShell`
+.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/1/AasReferables/AssetAdministrationShell`
 a|Asset Administration Shell
 
-.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/BasicEventElement`
+.2+e|BasicEventElement | `\https://admin-shell.io/aas/3/1/AasReferables/BasicEventElement`
 a|Basic event element
 
-.2+e|Blob | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Blob`
+.2+e|Blob | `\https://admin-shell.io/aas/3/1/AasReferables/Blob`
 a|Blob
 
-.2+e|Capability | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Capability`
+.2+e|Capability | `\https://admin-shell.io/aas/3/1/AasReferables/Capability`
 a|Capability
 
-
-
-.2+e|DataElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/DataElement`
+.2+e|ConceptDescription | `\https://admin-shell.io/aas/3/1/AasReferables/ConceptDescription`
 a|
-Data Element
+Concept description
+
+.2+e|DataElement | `\https://admin-shell.io/aas/3/1/AasReferables/DataElement`
+a|
+Data element
 
 
 ====
@@ -633,10 +644,10 @@ Note: data elements are abstract, i.e. if a key uses "DataElement", the referenc
 ====
 
 
-.2+e|Entity | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Entity`
+.2+e|Entity | `\https://admin-shell.io/aas/3/1/AasReferables/Entity`
 a|Entity
 
-.2+e|EventElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/EventElement`
+.2+e|EventElement | `\https://admin-shell.io/aas/3/1/AasReferables/EventElement`
 a|
 Event
 
@@ -646,39 +657,46 @@ Note: event element is abstract.
 ====
 
 
-.2+e|File | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/File`
+.2+e|File | `\https://admin-shell.io/aas/3/1/AasReferables/File`
 a|File
 
 
+.2+e|Identifiable | `\https://admin-shell.io/aas/3/1/AasReferables/Identifiable`
+a|
+Identifiable
+====
+Note: identifiables are abstract, i.e. if a key uses "Identifiable", the reference may be an Asset Administration Shell, a concept description, etc.
+====
 
-
-
-.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/MultiLanguageProperty`
+.2+e|MultiLanguageProperty | `\https://admin-shell.io/aas/3/1/AasReferables/MultiLanguageProperty`
 a|Property with a value that can be provided in multiple languages
 
-.2+e|Operation| `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Operation`
+.2+e|Operation| `\https://admin-shell.io/aas/3/1/AasReferables/Operation`
 a|Operation
 
-.2+e|Property | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Property`
+.2+e|Property | `\https://admin-shell.io/aas/3/1/AasReferables/Property`
 a|Property
 
-.2+e|Range | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Range`
+.2+e|Range | `\https://admin-shell.io/aas/3/1/AasReferables/Range`
 a|Range with min and max
 
-.2+e|Referable | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/Referable`
+.2+e|Referable | `\https://admin-shell.io/aas/3/1/AasReferables/Referable`
 a|
 ====
 Note: referables are abstract, i.e. if a key uses "Referable", the reference may be an Asset Administration Shell, a property, etc.
 ====
 
-.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/ReferenceElement`
+.2+e|ReferenceElement | `\https://admin-shell.io/aas/3/1/AasReferables/ReferenceElement`
 a|Reference
 
-.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/RelationshipElement`
+.2+e|RelationshipElement | `\https://admin-shell.io/aas/3/1/AasReferables/RelationshipElement`
 a|Relationship
 
+.2+e|Submodel | `\https://admin-shell.io/aas/3/1/AasReferables/Submodel`
+a|
+Submodel
 
-.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElement`
+.2+e|SubmodelElement | `\https://admin-shell.io/aas/3/1/AasReferables/SubmodelElement`
 a|
 Submodel element
 
@@ -688,21 +706,26 @@ Note: submodel elements are abstract, i.e. if a key uses "SubmodelElement", the 
 ====
 
 
-.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElementCollection`
+.2+e|SubmodelElementCollection | `\https://admin-shell.io/aas/3/1/AasReferables/SubmodelElementCollection`
 a|Struct of submodel elements
 
-.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/1/AasReferableNonIdentifiables/SubmodelElementList`
+.2+e|SubmodelElementList | `\https://admin-shell.io/aas/3/1/AasReferables/SubmodelElementList`
 a|List of submodel elements
 |===
 
+
+
 {empty} +
+
+
+
 
 [.table-with-appendix-table]
 [cols="30%h,70%"]
 |===
 |Enumeration: e|[[GenericFragmentKeys]]GenericFragmentKeys
 |Explanation: a|
-Enumeration of different fragment key value types within a key
+Enumeration of generic fragment key value types within a key
 
 
 ====
@@ -780,6 +803,47 @@ h|Explanation
 a|Global reference
 
 |===
+
+{empty} +
+
+[.table-with-appendix-table]
+[cols="30%h,70%"]
+|===
+h|Enumeration: e|[[GloballyIdentifiables]]GloballyIdentifiables
+h|Explanation: a|Enumeration of globally identifiable elements
+h|Set of: |`\https://admin-shell.io/aas/3/1/GenericGloballyIdentifiables`, `\https://admin-shell.io/aas/3/1/AasIdentifiables`
+h|ID: | `\https://admin-shell.io/aas/3/1/GloballyIdentifiables`
+
+.2+h|Literal h| ID
+h|Explanation
+
+
+
+.2+e|AssetAdministrationShell | `\https://admin-shell.io/aas/3/1/GloballyIdentifiables/AssetAdministrationShell`
+a|Asset Administration Shell
+
+.2+e|ConceptDescription | `\https://admin-shell.io/aas/3/1/GloballyIdentifiables/ConceptDescription`
+a|Concept description
+
+.2+e|GlobalReference | `\https://admin-shell.io/aas/3/1/GloballyIdentifiables/GlobalReference`
+a|Global reference
+
+.2+e|Identifiable | `\https://admin-shell.io/aas/3/1/GloballyIdentifiables/Identifiable`
+a|
+Identifiable
+
+
+====
+Note: Identifiables are abstract, i.e. if a key uses "Identifiable", the reference may be an Asset Administration Shell, a submodel, or a concept description.
+====
+
+
+.2+e|Submodel | `\https://admin-shell.io/aas/3/1/GloballyIdentifiables/Submodel`
+a|Submodel
+
+|===
+
+{empty} +
 
 == Constraints
 

--- a/documentation/IDTA-01001/modules/ROOT/partials/diagrams/50-key.puml
+++ b/documentation/IDTA-01001/modules/ROOT/partials/diagrams/50-key.puml
@@ -17,7 +17,7 @@ enum AasReferables <<enumeration>> {
   Referable
 }
 
-enum AasReferablesNonIdentifiables <<enumeration>>
+enum AasReferableNonIdentifiables <<enumeration>>
 
 enum GloballyIdentifiables <<enumeration>>
 
@@ -30,10 +30,10 @@ KeyTypes --|> FragmentKeys
 KeyTypes --|> AasReferables
 KeyTypes --|> GloballyIdentifiables
 FragmentKeys --|> GenericFragmentKeys
-FragmentKeys --|> AasReferablesNonIdentifiables
-AasReferables --|> AasReferablesNonIdentifiables
+FragmentKeys --|> AasReferableNonIdentifiables
+AasReferables --|> AasReferableNonIdentifiables
 AasReferables --|> AasIdentifiables
-AasReferablesNonIdentifiables --|> AasSubmodelElements
+AasReferableNonIdentifiables --|> AasSubmodelElements
 GloballyIdentifiables --|> AasIdentifiables
 GloballyIdentifiables --|> GenericGloballyIdentifiables
 @enduml


### PR DESCRIPTION
Bugfix figure for logical enumerations:
AasReferablesNonIdentifiables -> AasReferableNonIdentifiables

add missing enumerations

correct and update existing enumeration
no reuse of value metamodel semnanticd ID: new ones for every value conformant to Clause "Grammar Semantic IDs for Metamodel"

add new chapter headline for logical enumerations