### PR TITLE
Update version of opinionated-commit-message in workflow

### DIFF
--- a/.github/workflows/check-title-and-description-of-pull-request.yml
+++ b/.github/workflows/check-title-and-description-of-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Check the title and description of the pull request
-        uses: mristin/opinionated-commit-message@v3.0.0
+        uses: mristin/opinionated-commit-message@v3.1.1
         with:
           path-to-additional-verbs: .github/workflows/AdditionalVerbsInImperativeMood.txt
 


### PR DESCRIPTION
Previously, we used an older version of 
[mristin/opinionated-commit-message] in our
`check_title_and_description` workflow, which lead
to erroneous failing of some PR pipelines. 

This updates our CI workflow to use the newest 
available version of this checker. 

Fixes #442


[mristin/opinionated-commit-message]: https://github.com/mristin/opinionated-commit-message
