### PR TITLE
closes Bug #540 maxLength FileValue is 2048 and maxLength contentType is 128

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/mappings/encodings/valueonly-json-schema.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/mappings/encodings/valueonly-json-schema.adoc
@@ -66,7 +66,7 @@ for an example that validates against this schema
         "contentType": {
           "type": "string",
           "minLength": "1",
-          "maxLength": "100"
+          "maxLength": "128"
         },
         "value": {
           "type": "string",
@@ -109,12 +109,12 @@ for an example that validates against this schema
         "contentType": {
           "type": "string",
           "minLength": "1",
-          "maxLength": "100"
+          "maxLength": "128"
         },
         "value": {
           "type": "string",
           "minLength": "1",
-          "maxLength": "2000"
+          "maxLength": "2048"
         }
       },
       "additionalProperties": false

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/datatypes.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/datatypes.adoc
@@ -383,7 +383,7 @@ NaN
 
 "2000-01-01+12:05"
 
-| e|xs:time |Times (hh:mm:ss.sss…​) with or without time zone a|
+| e|xs:time |Times (hh:mm:ss.sss…) with or without time zone a|
 "14:23:00"
 
 "14:23:00.527634Z"


### PR DESCRIPTION
closes Bug #540 
* maxLength FileValue is 2048 and 
* maxLength contentType is 128

+ remove special char in file (editorial only)