### PR TITLE
Reverts the sequence of elements in embeddedDataSpecification of XML schema

### DIFF
--- a/schemas/xml/AAS.xsd
+++ b/schemas/xml/AAS.xsd
@@ -277,6 +277,7 @@
   </xs:group>
   <xs:group name="embeddedDataSpecification">
     <xs:sequence>
+      <xs:element name="dataSpecification" type="reference_t"/>
       <xs:element name="dataSpecificationContent">
         <xs:complexType>
           <xs:sequence>
@@ -284,7 +285,6 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="dataSpecification" type="reference_t"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="entity">


### PR DESCRIPTION
What changed:
Reverted the order of elements inside the embeddedDataSpecification group to match the correct sequence from version 3.0 — placing dataSpecification before dataSpecificationContent.

Why:
I think the element order was unintentionally swapped in the 3.1.0 schema, which deviated from the intended structure defined in version 3.0. This update corrects that inconsistency and restores the proper sequence as per the original specification logic.

Issue: #585 

I created this PR for the discussion and this PR can be further extended based on the outcomes of the discussion.