### PR TITLE
docs(terms): add cross-spec terminology matrix (IDTA-01002/01004)

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
@@ -471,3 +471,45 @@ The following abbreviations are not used in the document but may be used as abbr
 |SME |SubmodelElement
 |SML |SubmodelElementList
 |===
+
+[#cross-spec-terminology]
+== Terminology Across IDTA-01001, IDTA-01002 and IDTA-01004
+
+The following table relates the core AAS concepts across the three specifications. It is intended as a quick cross-reference for readers of the API (IDTA-01002) and Security (IDTA-01004) specifications. All three specifications use the same underlying entities; only their textual representations differ (metamodel class name, HTTP path segment, query / access-rule FieldIdentifier prefix).
+
+[cols="2,2,1,3",options="header"]
+|===
+| Metamodel Class | API Resource / Path Segment | Query / Access-Rule Prefix | Example
+
+| AssetAdministrationShell
+| `/shells/{aasIdentifier}`
+| `$aas`
+| `$aas("https://example.com/aas/1")`
+
+| Submodel
+| `/submodels/{submodelIdentifier}`
+| `$sm`
+| `$sm("https://example.com/sm/1")`
+
+| SubmodelElement
+| `.../submodel-elements/{idShortPath}`
+| `$sme`
+| `$sme("https://example.com/sm/1").path.to.element`
+
+| ConceptDescription
+| `/concept-descriptions/{cdIdentifier}`
+| `$cd`
+| `$cd("https://example.com/cd/1")`
+
+| AssetAdministrationShellDescriptor
+| `/shell-descriptors/{aasIdentifier}`
+| `$aasdesc`
+| `$aasdesc("https://example.com/aas/1")`
+
+| SubmodelDescriptor
+| `/submodel-descriptors/{submodelIdentifier}`
+| `$smdesc`
+| `$smdesc("https://example.com/sm/1")`
+|===
+
+The FieldIdentifier prefix is always lower-case (`$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc`, `$smdesc`); variants such as `$aasDesc` or `$SmDesc` are not valid and MUST be rejected by parsers of both the AAS Query Language (IDTA-01002) and the Access Rule Model (IDTA-01004).


### PR DESCRIPTION
## Summary

Add a normative cross-specification terminology matrix at the end of the "Terms, Definitions and Abbreviations" section. The table maps every top-level AAS entity to its API resource / path segment (IDTA-01002) and its Query / Access-Rule FieldIdentifier prefix (IDTA-01002 Query Language and IDTA-01004 Access Rule Model).

## Problem

The three specifications use different surface forms for the same concept:

- Metamodel uses class names (`AssetAdministrationShell`, `Submodel`, ...).
- API uses URL path segments (`/shells`, `/submodels`, ...).
- Query / Access Rules use lower-case prefixes (`$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc`, `$smdesc`).

Readers who only work with one spec keep producing small inconsistencies (e.g. `$aasDesc` vs. `$aasdesc`, "Shell" vs. "AAS"), and new editors have to rediscover the mapping each review cycle.

## Solution

Add a single cross-reference table to the Metamodel's Terms section. The API and Security specs can reference this table instead of duplicating the mapping. The table also states that prefixes are lower-case and that variants like `$aasDesc` MUST be rejected by parsers.

## Affected files

- `documentation/IDTA-01001/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc`

## Review notes

- No normative changes to the Metamodel itself; this is a cross-spec clarification.
- API PR (to follow) and Security PR (to follow) will reference this section.

Refs: Review Finding T-09
