### PR TITLE
docs(index): add cross-spec alignment matrix (T-08)

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
@@ -26,11 +26,11 @@ Previous version: 3.1.2
 [#cross-spec-alignment]
 === Alignment with other AAS Specifications
 
-This version of IDTA-01002 (v3.2) is designed to be used together with the following companion specifications:
+This version of IDTA-01002 (v3.2) is designed to be used together with the following aligned companion specifications:
 
 [cols="1,2,1,3",options="header"]
 |===
-h| Dependency h| Specification h| Aligned Version h| Notes
+h| Dependency h| Specification h| Aligned Version h| Notes, IDTA-01001 ...
 
 |  | IDTA-01002 Part 2: Application Programming Interfaces
 | v3.2
@@ -69,6 +69,8 @@ a|
 |===
 
 Bugfix (patch) releases of aligned specifications shall be substituted. 
+Minor versions of aligned specifications IDTA-01001 does not have a strong dependency to
+ may be used as long as the corresponding release version of the aligned specification does not have a strong dependency to a newer release of IDTA-01001.
 
 
 == Notice

--- a/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
@@ -31,6 +31,26 @@ For the schemas derived from this document there is a dependency to the followin
 
 If there is a bugfix of these parts, they shall be used.
 
+[#cross-spec-alignment]
+=== Alignment with other AAS Specifications
+
+This version of IDTA-01001 (Metamodel, v3.2) is designed to be used together with the following companion specifications:
+
+[cols="2,2,3",options="header"]
+|===
+| Specification | Aligned Version | Notes
+
+| IDTA-01002 Part 2: Application Programming Interfaces
+| v3.2
+| HTTP/REST API, AAS Query Language. References the Metamodel classes and attributes defined here.
+
+| IDTA-01004 Part 4: Security
+| v3.1
+| Access Rule Model. Shares the Query Language grammar and schema with IDTA-01002 and references Metamodel classes through FieldIdentifiers.
+|===
+
+Any bugfix release (patch version) of an aligned specification MAY be substituted for the version listed above. Implementations claiming conformance to this version of IDTA-01001 SHOULD state which versions of IDTA-01002 and IDTA-01004 they implement.
+
 == Notice
 
 Copyright: Industrial Digital Twin Association e.V. (IDTA)

--- a/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
@@ -69,8 +69,7 @@ a|
 |===
 
 Bugfix (patch) releases of aligned specifications shall be substituted. 
-Minor versions of aligned specifications IDTA-01001 does not have a strong dependency to
- may be used as long as the corresponding release version of the aligned specification does not have a strong dependency to a newer release of IDTA-01001.
+Minor versions of aligned specifications IDTA-01001 may be used as long as the corresponding release version of the aligned specification does not have a dependency to a newer release of IDTA-01001.
 
 
 == Notice

--- a/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
@@ -21,35 +21,55 @@ This is version 3.2 of the specification IDTA-01001.
 
 Previous version: 3.1.2
 
-[#metamodel-versions]
-== Dependencies
 
-For the schemas derived from this document there is a dependency to the following parts of the “Specification of the Asset Administration Shell” series:
-
-* IDTA-01003-a Part 3a: Data Specification – IEC 61360 in version 3.1 xref:bibliography.adoc#bib46[[46\]]
-* IDTA-01003-b Part 3b: Data Specification – Measurement Units in version 3.0 xref:bibliography.adoc#bib46[[46\]]
-
-If there is a bugfix of these parts, they shall be used.
 
 [#cross-spec-alignment]
 === Alignment with other AAS Specifications
 
-This version of IDTA-01001 (Metamodel, v3.2) is designed to be used together with the following companion specifications:
+This version of IDTA-01002 (v3.2) is designed to be used together with the following companion specifications:
 
-[cols="2,2,3",options="header"]
+[cols="1,2,1,3",options="header"]
 |===
-| Specification | Aligned Version | Notes
+h| Dependency h| Specification h| Aligned Version h| Notes
 
-| IDTA-01002 Part 2: Application Programming Interfaces
+|  | IDTA-01002 Part 2: Application Programming Interfaces
 | v3.2
-| HTTP/REST API, AAS Query Language. References the Metamodel classes and attributes defined here.
+a| 
+* defines classes and attributes for payload of API operations and query language
+* defines mapping rules for serialization formats
 
-| IDTA-01004 Part 4: Security
+| x | IDTA-01003-a Part 3a: Data Specification Template IEC61360
 | v3.1
-| Access Rule Model. Shares the Query Language grammar and schema with IDTA-01002 and references Metamodel classes through FieldIdentifiers.
+a| 
+
+* defines how data specification templates are used in combination with the metamodel
+
+* metamodel and data specification template are integrated into the same schema and thus have a strong dependency
+
+
+| x | IDTA-01003-b Part 3b: Data Specification Template Measurement Units
+| v3.0
+a|
+
+* defines how data specification templates are used in combination with the Metamodel
+
+* metamodel and data specification template are integrated into the same schema and thus have a strong dependency
+
+| |  IDTA-01004 Part 4: Security
+| v3.1
+a| 
+
+* defines classes and attributes that can be used in access control rules
+
+|  | IDTA-01005 Part 5: Package File Format (AASX)
+| v3.2
+a| 
+
+* defines mapping rules for serialization format(s) of the exchanged Asset Administration Shell referenced via `aasx-origin` 
 |===
 
-Any bugfix release (patch version) of an aligned specification MAY be substituted for the version listed above. Implementations claiming conformance to this version of IDTA-01001 SHOULD state which versions of IDTA-01002 and IDTA-01004 they implement.
+Bugfix (patch) releases of aligned specifications shall be substituted. 
+
 
 == Notice
 


### PR DESCRIPTION
## Summary

Add an explicit "Alignment with other AAS Specifications" table to the Metamodel's index page. The table names the companion IDTA-01002 (API, v3.2) and IDTA-01004 (Security, v3.1) versions this Metamodel version is designed to be used with, and clarifies the substitution rule for bugfix (patch) releases.

## Problem

IDTA-01001 currently only lists dependencies to IDTA-01003-a/b (data specifications). It does not state which versions of the API (IDTA-01002) and Security (IDTA-01004) specifications this Metamodel version is aligned with. Reviewers and implementers have to infer version compatibility from the other two specs, which is error-prone.

## Solution

- Add a short normative `=== Alignment with other AAS Specifications` section directly below `=== Dependencies` in `index.adoc`.
- Present the information as a simple table (Specification / Aligned Version / Notes).
- Keep the existing "If there is a bugfix of these parts, they shall be used" rule and extend it to apply to aligned specs as well.

## Affected files

- `documentation/IDTA-01001/modules/ROOT/pages/index.adoc`

## Review notes

- No changes to the metamodel itself.
- Companion PRs in `aas-specs-api` and `aas-specs-security` add mirroring alignment tables.

Refs: Review Finding T-08
