### PR TITLE
Incorporate further Findings from Review-Phase

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
@@ -576,6 +576,7 @@ h| EN 18223 RelatedResource h| AAS SME File h| IDTA-02004 Handover Documentation
 
 [[section-json-serialization-normal]]
 == JSON Serialization Expanded vs. Normal
+The expanded serialization is optional (see EN 18223).
 The AAS "Normal" serialization and the "expanded" EN 18223 serialization are similar when it comes to the rules of derivation the serialization from the UML model. 
 However, since the UML model differ also the serialization differs.
 
@@ -655,6 +656,7 @@ The "objectType" in JSON serialization of AAS is mapped to "objectType" in EN 18
 == XML Serialization compressed vs. Value-Only
 
 EN 18223 also defines a XML serialization for the compressed representation (Annex B).
+The XML serialization is optional (see EN 18216).
 The AAS does not support a Value-Only serialization for XML, only for JSON. 
 However, a corresponding serialization would be straightforward compared to AAS Value-Only as it is in EN 18223 compared to JSON compressed. 
 
@@ -664,6 +666,7 @@ EN 18223 does not define a XML serialization for the expanded representation.
 
 == JSON-LD Serialization 
 
+The JSON-LD serialization is optional (see EN 18216).
 EN 18216 requires that a JSON-LD representation shall be processable by a regular JSON parser, allowing the possibility of including linked data context for advanced semantic processing.
 However, in EN 18223 no examples or normative text is provided for JSON-LD representation.
 The AAS does not support a standardized JSON-LD representation.

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
@@ -22,8 +22,8 @@ To support the implementation of DPPs, 8 standards have been developed:
 * EN 18222:2026 – Digital Product Passport – Application Programming Interfaces (APIs) for the product passport lifecycle management and searchability
 * EN 18223:2026 – Digital Product Passport – System interoperability
 * EN 18221:2026 – Digital product passport – data storage, archiving, and data persistence
-* EN 18239:2026 – Digital Product Passport – access rights management, information system security, and business confidentiality 
-* EN 18246:2026 – Digital Product Passport – Data authentication, reliability and integrity
+* EN 18239:2026 – Digital Product Passport – access rights management, information system security, and business confidentiality  (not yet released)
+* EN 18246:2026 – Digital Product Passport – Data authentication, reliability and integrity (not yet released)
  
 This annex specifies how the requirements as specified in
  

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
@@ -58,8 +58,8 @@ The Digital Battery Passport provides a clear example of this relationship. It i
 To create the complete passport, these submodels are merged with the DPP metadata submodel defined herein, resulting in a comprehensive Digital Product Passport conformant to regulation.
 
 [[image_dpp_aas_batteryPassport]]
-.Example: AAS for Digital Battery Passport
-image::dpp-aas-battery-passport.png
+.Example: DPP based on AAS for Digital Battery Passport
+image::dpp-aas-battery-passport.png[Example: DPP based on AAS for Digital Battery Passport]
 
 The primary advantage of using an Asset Administration Shell (AAS) to implement a Digital Product Passport (DPP) is its modular design, which contrasts with the monolithic structure assumed by the JTC24 specification.
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
@@ -661,3 +661,9 @@ However, a corresponding serialization would be straightforward compared to AAS 
 == XML Serialization expanded vs. Normal
 
 EN 18223 does not define a XML serialization for the expanded representation.
+
+== JSON-LD Serialization 
+
+EN 18216 requires that a JSON-LD representation shall be processable by a regular JSON parser, allowing the possibility of including linked data context for advanced semantic processing.
+However, in EN 18223 no examples or normative text is provided for JSON-LD representation.
+The AAS does not support a standardized JSON-LD representation.

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
@@ -157,16 +157,24 @@ For DPP Metadata there is exactly one correct serialization since it is part of 
 [cols="22%,28%,23%,27%"]
 |===
 h| EN 18223 h| IDTA-01001 V3.2 h| IDTA-02006 V3.0 h| comment
-| digitalProductPassportId | AssetAdministrationShell/id| -- a| Although the ID of the AAS is very similar to the DPP ID they are not necessarily the same because the DPP is a monolithic output whereas the ID of an AAS does not imply a specific set of data in a specific point in time because the Submodels are identifiable
-| uniqueProductIdentifier | AssetInformation/globalAssetId | URIOfTheProduct  a| Identifier types allowed are specified in EN 18219
-| granularity  | assetKind	| --  a| for mapping of enumeration values see <<mapping-granularity>>
+| digitalProductPassportId | `\https://admin-shell.io/aas/3/2/Identifiable/id`  
+
+AssetAdministrationShell/id| -- a| Although the ID of the AAS is very similar to the DPP ID they are not necessarily the same because the DPP is a monolithic output whereas the ID of an AAS does not imply a specific set of data in a specific point in time because the Submodels are identifiable
+| uniqueProductIdentifier | `\https://admin-shell.io/aas/3/2/AssetInformation/globalAssetId` 
+
+AssetInformation/globalAssetId | URIOfTheProduct  a| Identifier types allowed are specified in EN 18219
+| granularity  | `\https://admin-shell.io/aas/3/2/AssetInformation/assetKind` 
+
+assetKind	| --  a| for mapping of enumeration values see <<mapping-granularity>>
 | dppSchemaVersion | -- 	| a| In EN 1822:2026 no Schema is defined and thus there is also no schema version.
 | dppStatus | -- 			| --  a| In EN 1822:2026 no enumeration is specified for the Status, only example values are given like "Active".
 The AAS does not support administrative information on its status.
 However, status of the AAS does not need to be identical to the status of the DPP.
 
 
-| lastUpdate | AdministrativeInformation/updatedAt | --  a| EN 18223 does not support explicit versioning (like the AAS does), versioning is supported via the "lastUpdate" attribute in DPPs
+| lastUpdate | `\https://admin-shell.io/aas/3/1/AdministrativeInformation/updatedAt` 
+
+AdministrativeInformation/updatedAt | --  a| EN 18223 does not support explicit versioning (like the AAS does), versioning is supported via the "lastUpdate" attribute in DPPs
 | economicOperatorId | -- | -- a| Identifier types allowed are specified in EN 18219
 | facilityId | -- | UniqueFacilityIdentifier a| Identifier types allowed are specified in EN 18219
 | contentSpecificationIds | -- | a| This attribute reminds of AssetAdministrationShell/submodels because it lists the data sets relevant for the different DPP(s). 
@@ -181,7 +189,11 @@ A DPP may contain data from several delegated acts, i.e. from different regulati
 [.table-with-appendix-table]
 [cols="25%,30%,45%"]
 |===
-h| EN 18223 granularity h| AAS AssetKind  h| comment
+h| EN 18223 granularity h| AAS AssetKind
+
+`\https://admin-shell.io/aas/3/2/AssetKind` 
+
+  h| comment
 
 |Item 	| Instance 		a| 
 |Model 	| Type 			a| 
@@ -215,23 +227,60 @@ https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.1.2/mappings/m
 |===
 h| EN 18223  h| AAS   h| comment
 
-|DataElement 	(abstract)			| SubmodelElement (SME)	(abstract)	a|
-|MultiLanguageDataElement 	| MultiLanguageProperty 			a| see <<section-mlp>> for topics on serialization
-|SingleValuedDataElement 	a| Property 
+|DataElement 	(abstract)			| `\https://admin-shell.io/aas/3/2/SubmodelElement` 
+
+SubmodelElement (SME)	(abstract)	a|
+ 
+|MultiLanguageDataElement 	| `\https://admin-shell.io/aas/3/2/MultiLanguageProperty` 
+
+MultiLanguageProperty 			a| see <<section-mlp>> for topics on serialization
+
+|SingleValuedDataElement 	a| `\https://admin-shell.io/aas/3/2/Property` 
+
+Property 
+
+`\https://admin-shell.io/aas/3/2/Blob` 
 
 Blob		a| A Blob can be realized with a EN 18223 SingleValuedDataElement with valueDataType "xsd:base64Binary" 
-|MultiValuedDataElement		| SubmodelElementList 			a|  SubmodelElementLists only with Elements of type MultiLanguageProperty, SubmodelElementCollection, File or Property: they can be directly mapped
-|DataElementCollection 		| SubmodelElementCollection a|
-|RelatedResource 			| File	a|see <<section-file>> for topics on serialization
-|--| AnnotatedRelationshipElement a| can be realized with a EN 18223 DataElementCollection
-|--| BasicEventElement a| Events are not supported in EN 18223 but could be realized with a EN 18223 DataElementCollection
-|--| Capability a| not supported in EN 18223
-|--| DataElement (abstract) a| EN 18223 MultiLanguageDataElement and SingleValuedDataElement and RelatedResource correspond to AAS DataElements
-|--| Entity a| can be realized with a EN 18223 DataElementCollection
-|--| Event (abstract) a| Events are not supported in EN 18223
-|--| Range a| can be realized with a EN 18223 DataElementCollection
-|--| ReferenceElement a| could be realized with a EN 18223 DataElementCollection and MultiValuedDataElement, however, it is not foreseen in EN 18223 that elements are referenced
-|--| RelationshipElement a| can be realized with a EN 18223 DataElementCollection
+
+|MultiValuedDataElement		| `\https://admin-shell.io/aas/3/2/SubmodelElementList` 
+
+SubmodelElementList 			a|  SubmodelElementLists only with Elements of type MultiLanguageProperty, SubmodelElementCollection, File or Property: they can be directly mapped
+ 
+|DataElementCollection 		| `\https://admin-shell.io/aas/3/2/SubmodelElementCollection` 
+
+SubmodelElementCollection a|
+ 
+|RelatedResource 			| `\https://admin-shell.io/aas/3/2/File` 
+
+ File	a|see <<section-file>> for topics on serialization
+|--| `\https://admin-shell.io/aas/3/2/AnnotatedRelationshipElement` 
+
+AnnotatedRelationshipElement a| can be realized with a EN 18223 DataElementCollection
+|--| `\https://admin-shell.io/aas/3/2/BasicEventElement` 
+
+BasicEventElement a| Events are not supported in EN 18223 but could be realized with a EN 18223 DataElementCollection
+|--| `\https://admin-shell.io/aas/3/2/Capability` 
+
+ Capability a| not supported in EN 18223
+|--| `\https://admin-shell.io/aas/3/2/DataElement` 
+
+ DataElement (abstract) a| EN 18223 MultiLanguageDataElement and SingleValuedDataElement and RelatedResource correspond to AAS DataElements
+|--| `\https://admin-shell.io/aas/3/2/Entity` 
+
+Entity a| can be realized with a EN 18223 DataElementCollection
+|--| `\https://admin-shell.io/aas/3/2/Event` 
+
+Event (abstract) a| Events are not supported in EN 18223
+|--| `\https://admin-shell.io/aas/3/2/Range`
+
+Range a| can be realized with a EN 18223 DataElementCollection
+|--| `\https://admin-shell.io/aas/3/2/ReferenceElement` 
+
+ReferenceElement a| could be realized with a EN 18223 DataElementCollection and MultiValuedDataElement, however, it is not foreseen in EN 18223 that elements are referenced
+|--| `\https://admin-shell.io/aas/3/2/RelationshipElement` 
+
+RelationshipElement a| can be realized with a EN 18223 DataElementCollection
 |===
 
 == Creating of DPP with several Submodels
@@ -376,7 +425,7 @@ see IDTA-01001 Asset Administration Shell Specifications, Part 1.
 
 
 [[section-json-serialization-value-only]]
-== JSON Serialization Value-Only 
+== JSON Serialization Compressed vs. Value-Only 
 
 In AAS "Normal" is considered the standard serialization but others are supported as well. 
 In this context especially the mapping "Value-Only" is of interest.
@@ -514,15 +563,15 @@ but adapted for the example in this document)
 |===
 h| EN 18223 RelatedResource h| AAS SME File h| IDTA-02004 Handover Documentation h| comment
 
-|contentType 		| contentType			|	*DigitalFile* realized with SME File	a| 
-|url				| value					|	*DigitalFile* realized with SME File	a|
+|contentType 		| `\https://admin-shell.io/aas/3/2/File/contentType` +	 contentType			|	*DigitalFile* realized with SME File	a| 
+|url				| `\https://admin-shell.io/aas/3/2/File/value` +	value					|	*DigitalFile* realized with SME File	a|
 |resourceTitle		| -- 					|    title	a|
 |language			| --					| 		    a| localized, i.e. add language. If not existing add a substitute language (if allowed)
 |===
 
 
 [[section-json-serialization-normal]]
-== JSON Serialization Normal
+== JSON Serialization Expanded vs. Normal
 The AAS "Normal" serialization and the "expanded" EN 18223 serialization are similar when it comes to the rules of derivation the serialization from the UML model. 
 However, since the UML model differ also the serialization differs.
 
@@ -532,12 +581,12 @@ However, since the UML model differ also the serialization differs.
 |===
 h| EN 18223 h| AAS   h| comment
 
-|	DataElement/elementId			| 		Referable/idShort	a|		In AAS there are more restrictions on how to choose the idShort, in EN 18223 the elementId is just a String.
-|	DataElement/dictionaryReference	| 	HasSemantics/semanticId		a|	In EN 18223 the dictionaryReference is just a String, in AAS it is a Reference.	
-|	SingleValuedDataElement/valueDataType		|  Property/valueType						a| 	The allowed values are identical in both, the AAS and EN 18223 specification with only one difference: in AAS the prefix "xs:" is used, in EN 18223 the prefix is "xsd".
-|	MultiValuedDataElement/valueDataType		| 		SubmodelElementList/valueTypeListElement			a| 
-|	MultiLanguageDataElement		| 		MultiLanguageProperty			a|  see <<section-mlp>>, compressed and expanded in EN 18223 are identical in this case
-|	RelatedResource		| 		File			a| 		see <<section-file>>, compressed and expanded in EN 18223 are identical in this case
+|	DataElement/elementId			| `\https://admin-shell.io/aas/3/2/Referable/idShort` +		Referable/idShort	a|		In AAS there are more restrictions on how to choose the idShort, in EN 18223 the elementId is just a String.
+|	DataElement/dictionaryReference	| 	`\https://admin-shell.io/aas/3/2/HasSemantics/semanticId` + HasSemantics/semanticId		a|	In EN 18223 the dictionaryReference is just a String, in AAS it is a Reference.	
+|	SingleValuedDataElement/valueDataType		|  `\https://admin-shell.io/aas/3/2/Property/valueType` + Property/valueType						a| 	The allowed values are identical in both, the AAS and EN 18223 specification with only one difference: in AAS the prefix "xs:" is used, in EN 18223 the prefix is "xsd".
+|	MultiValuedDataElement/valueDataType		| 	`\https://admin-shell.io/aas/3/1/SubmodelElementList/valueTypeListElement`  + 	SubmodelElementList/valueTypeListElement			a| 
+|	MultiLanguageDataElement		| 	`\https://admin-shell.io/aas/3/1/MultiLanguageProperty` + 	MultiLanguageProperty			a|  see <<section-mlp>>, compressed and expanded in EN 18223 are identical in this case
+|	RelatedResource		| `\https://admin-shell.io/aas/3/1/File` + 		File			a| 		see <<section-file>>, compressed and expanded in EN 18223 are identical in this case
 |===
 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
@@ -31,6 +31,10 @@ This annex specifies how the requirements as specified in
  
 are mapped to the AAS Metamodel.
 
+In EN 18216 it is specified that JSON shall be used for syntactic interoperability. 
+In addition to JSON also XML and JSON-LD may be used based on http content negotiation.
+A JSON-LD representation shall be processable by a regular JSON parser, allowing the possibility of including linked data context for advanced semantic processing.
+
 == General
 
 A Digital Product Passport (DPP) is a digital record of product characteristics throughout its life cycle [1]. 
@@ -648,7 +652,12 @@ The "objectType" in JSON serialization of AAS is mapped to "objectType" in EN 18
 }
 ----
 
-== XML compressed or Value-Only Serialization
+== XML Serialization compressed vs. Value-Only
 
+EN 18223 also defines a XML serialization for the compressed representation (Annex B).
 The AAS does not support a Value-Only serialization for XML, only for JSON. 
 However, a corresponding serialization would be straightforward compared to AAS Value-Only as it is in EN 18223 compared to JSON compressed. 
+
+== XML Serialization expanded vs. Normal
+
+EN 18223 does not define a XML serialization for the expanded representation.

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -104,8 +104,8 @@ h|Nc h|V3.2 Change w.r.t. V3.1.1 h|Comment
 [cols="5%,42%,48%",options="header",]
 |===
 h|Nc h|New Elements V3.2 vs V3.1 h|Comment
-|{empty} | xref:spec-metamodel/common.adoc#AdministrativeInformatio[AdministrativeInformation/createdAt]  a| add createdAt date attribute to enable performant querying of new objects
-|{empty} | xref:spec-metamodel/common.adoc#AdministrativeInformatio[AdministrativeInformation/updatedAt]  a| add updatedAt date attribute to enable DPP methods
+|{empty} | xref:spec-metamodel/common.adoc#AdministrativeInformation[AdministrativeInformation/createdAt]  a| add createdAt date attribute to enable performant querying of new objects
+|{empty} | xref:spec-metamodel/common.adoc#AdministrativeInformation[AdministrativeInformation/updatedAt]  a| add updatedAt date attribute to enable DPP methods
 |{empty} | xref:spec-metamodel/core.adoc#AssetKind[AssetKind/Batch] a| add new value "Batch" to enumeration AssetKind
 |===
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -42,19 +42,19 @@ They had separate sections and tables documenting the changes.
 
 Major Changes:
 
-* CHANGED: new attributes for creation and update date in AdministrationInformation  (https://github.com/admin-shell-io/aas-specs-metamodel/issues/484[#484])
-* CHANGED: new value to enumeration AssetKind: Batch to support Digital Product Passports (https://github.com/admin-shell-io/aas-specs-metamodel/issues/483[#483])
-* NEW: new section in the annex on metamodel and payload mapping for implementing the digital product passport (DPP) based on EN 18223
+* CHANGED: attributes for creation and update date in AdministrationInformation  (https://github.com/admin-shell-io/aas-specs-metamodel/issues/484[#484])
+* CHANGED: value to enumeration AssetKind: Batch to support Digital Product Passports (https://github.com/admin-shell-io/aas-specs-metamodel/issues/483[#483])
+* NEW: section in the annex on metamodel and payload mapping for implementing the digital product passport (DPP) based on EN 18223
 * NEW: explanatory section added for Value-Only for Operations (https://github.com/admin-shell-io/aas-specs-metamodel/issues/652[#652])
 * CHANGED: Value-Only JSON Schema - add referredSemanticId to data type Reference (https://github.com/admin-shell-io/aas-specs-metamodel/issues/651[#651]) 
 * CHANGED: SubmodelElement "Range" - remove conditions "If the min value is missing, the value is assumed to be negative infinite." and "If the max value is missing, the value is assumed to be positive infinite." 
   (https://github.com/admin-shell-io/aas-specs-metamodel/issues/639[#639])
-* NEW: new Constraint AASd-137 for References (https://github.com/admin-shell-io/aas-specs-metamodel/issues/592[#592])
-* NEW: new Constraint AASd-138 for SubmodelElementList for OperationVariable (https://github.com/admin-shell-io/aas-specs-metamodel/issues/462[#462])
+* NEW: Constraint AASd-137 for References (https://github.com/admin-shell-io/aas-specs-metamodel/issues/592[#592])
+* NEW: Constraint AASd-138 for SubmodelElementList for OperationVariable (https://github.com/admin-shell-io/aas-specs-metamodel/issues/462[#462])
 * CHANGED: Constraint AASd-129, add exception if the SubmodelElement is part of an OperationVariable (https://github.com/admin-shell-io/aas-specs-metamodel/issues/462[#462])
 * CHANGED: changed description of Constraint AASd-116, made more generic to avoid frequent updates (https://github.com/admin-shell-io/aas-specs-metamodel/issues/674[#674])
-* ADDED: A minimum recursion depth of 32 for Container-Elements should be supported. Note: This means for certification a maximum of 32 recursion test cases should be tested. (https://github.com/admin-shell-io/aas-specs-metamodel/issues/333[#333])
-
+* ADDED: a minimum recursion depth of 32 for Container-Elements should be supported. Note: This means for certification a maximum of 32 recursion test cases should be tested. (https://github.com/admin-shell-io/aas-specs-metamodel/issues/333[#333])
+* ADDED: explanatory text for handling of versions and dates in n xref:spec-metamodel/common.adoc#AdministrativeInformatio[AdministrativeInformation]
 
 
 Minor Changes:
@@ -72,7 +72,7 @@ Minor Changes:
 * ADDED: Handling of operations in Submodel with kind=Instance are handled identical to operation in Submodel Templates (Submodel with kind=Template) (https://github.com/admin-shell-io/aas-specs-metamodel/issues/462[#462])
 * CHANGED: update bibliography
 * CHANGED: editorial changes (including https://github.com/admin-shell-io/aas-specs-metamodel/issues/600[#600], https://github.com/admin-shell-io/aas-specs-metamodel/issues/636[#636], https://github.com/admin-shell-io/aas-specs-metamodel/issues/637[#637], https://github.com/admin-shell-io/aas-specs-metamodel/issues/638[#638] )
-
+* NEW: add to xref:./shared/versioning.adoc[Versioning] that bugfix releases are not no necessarily backward compatible
 
 Minor Bugfixes:
 
@@ -88,9 +88,9 @@ Minor Bugfixes:
 |===
 h|Nc h|V3.2 Change w.r.t. V3.1.1 h|Comment
 
-| {empty} | xref:spec-metamodel/core.adoc#AssetKind[AssetKind] a| Add new value "Batch" to enumeration AssetKind
+| {empty} | xref:spec-metamodel/core.adoc#AssetKind[AssetKind] a| add new value "Batch" to enumeration AssetKind to support DPP applications
 
-| x |Range a| remove conditions "If the min value is missing, the value is assumed to be negative infinite." and "If the max value is missing, the value is assumed to be positive infinite." 
+| x |xref:spec-metamodel/submodel-elements.adoc#Range[Range] a| remove conditions "If the min value is missing, the value is assumed to be negative infinite." and "If the max value is missing, the value is assumed to be positive infinite." 
    
    Note 1: some data types like float do have infinite in its value range per definition and should be used if infinite is needed. 
    
@@ -104,9 +104,9 @@ h|Nc h|V3.2 Change w.r.t. V3.1.1 h|Comment
 [cols="5%,42%,48%",options="header",]
 |===
 h|Nc h|New Elements V3.2 vs V3.1 h|Comment
-|{empty} | AdministrativeInformation/createdAt  a| 
-|{empty} | AdministrativeInformation/updatedAt  a| 
-|{empty} | xref:spec-metamodel/core.adoc#AssetKind[AssetKind/Batch] a| Add new value "Batch" to enumeration AssetKind
+|{empty} | xref:spec-metamodel/common.adoc#AdministrativeInformatio[AdministrativeInformation/createdAt]  a| add createdAt date attribute to enable performant querying of new objects
+|{empty} | xref:spec-metamodel/common.adoc#AdministrativeInformatio[AdministrativeInformation/updatedAt]  a| add updatedAt date attribute to enable DPP methods
+|{empty} | xref:spec-metamodel/core.adoc#AssetKind[AssetKind/Batch] a| add new value "Batch" to enumeration AssetKind
 |===
 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -54,7 +54,7 @@ Major Changes:
 * CHANGED: Constraint AASd-129, add exception if the SubmodelElement is part of an OperationVariable (https://github.com/admin-shell-io/aas-specs-metamodel/issues/462[#462])
 * CHANGED: changed description of Constraint AASd-116, made more generic to avoid frequent updates (https://github.com/admin-shell-io/aas-specs-metamodel/issues/674[#674])
 * ADDED: a minimum recursion depth of 32 for Container-Elements should be supported. Note: This means for certification a maximum of 32 recursion test cases should be tested. (https://github.com/admin-shell-io/aas-specs-metamodel/issues/333[#333])
-* ADDED: explanatory text for handling of versions and dates in n xref:spec-metamodel/common.adoc#AdministrativeInformation[AdministrativeInformation]
+* ADDED: explanatory text for handling of versions and dates in xref:spec-metamodel/common.adoc#AdministrativeInformation[AdministrativeInformation]
 
 
 Minor Changes:
@@ -262,8 +262,6 @@ https://github.com/admin-shell-io/aas-specs-metamodel/issues/471[#471],
 ** ADDED: add clause for Submodel Example (with properties from SMT Technical Data, not Families any longer)
 * CHANGED: update Schema for JSON-Value Serialization (https://github.com/admin-shell-io/aas-specs-metamodel/issues/389[#389])
 * REMOVED: remove recommendation to use external references for semanticId (https://github.com/admin-shell-io/aas-specs-metamodel/issues/376[#376]) and related attributes like valueId, semanticIdListElement and isCaseOf (https://github.com/admin-shell-io/aas-specs-metamodel/issues/396[#396], https://github.com/admin-shell-io/aas-specs-metamodel/issues/396[#396])
-* ADDED: add note: A maximum recursion depth of 32 for Container-Elements should be supported.
-This means for certification a maximum of 32 recursion test cases should be tested. (https://github.com/admin-shell-io/aas-specs-metamodel/issues/333[#333]) 
 * REMOVED: remove clauses on OPC UA and AutomationML mappings (https://github.com/admin-shell-io/aas-specs-metamodel/issues/373[#373], https://github.com/admin-shell-io/aas-specs-metamodel/issues/397[#397])
 * CHANGED: update explanatory text and notes in the context of AdministrativeInformation (https://github.com/admin-shell-io/aas-specs-metamodel/issues/331[#331])
 * CHANGED: move chapter "General" to Annex
@@ -287,7 +285,6 @@ Minor Changes:
 
 
 * CHANGED: add new data type "DateTimeUtc" and use it for attribute _lastUpdate_ of _BasicEventElement_ and attribute _timeStamp_ of _EventPayload_ (https://github.com/admin-shell-io/aas-specs-metamodel/issues/498[#498])
-* CHANGED: change recommendation for recursion: from "[..] maximum recursion depth of 32 [..]" to "A recursion depth of 32 should not be exceeded. The recommendation is to have not more than 8 recursions in a submodel. Test engines should test at least 16 recursions."
 * add Annex with overview of constraints (https://github.com/admin-shell-io/aas-specs-metamodel/issues/509[#509])
 * CHANGED: update Constraint AASd-116 (https://github.com/admin-shell-io/aas-specs-metamodel/issues/298[#298])
 * REMOVED: remove information on OPC UA mapping (https://github.com/admin-shell-io/aas-specs-metamodel/issues/373[#373])

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -54,7 +54,7 @@ Major Changes:
 * CHANGED: Constraint AASd-129, add exception if the SubmodelElement is part of an OperationVariable (https://github.com/admin-shell-io/aas-specs-metamodel/issues/462[#462])
 * CHANGED: changed description of Constraint AASd-116, made more generic to avoid frequent updates (https://github.com/admin-shell-io/aas-specs-metamodel/issues/674[#674])
 * ADDED: a minimum recursion depth of 32 for Container-Elements should be supported. Note: This means for certification a maximum of 32 recursion test cases should be tested. (https://github.com/admin-shell-io/aas-specs-metamodel/issues/333[#333])
-* ADDED: explanatory text for handling of versions and dates in n xref:spec-metamodel/common.adoc#AdministrativeInformatio[AdministrativeInformation]
+* ADDED: explanatory text for handling of versions and dates in n xref:spec-metamodel/common.adoc#AdministrativeInformation[AdministrativeInformation]
 
 
 Minor Changes:

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -73,6 +73,8 @@ Minor Changes:
 * CHANGED: update bibliography
 * CHANGED: editorial changes (including https://github.com/admin-shell-io/aas-specs-metamodel/issues/600[#600], https://github.com/admin-shell-io/aas-specs-metamodel/issues/636[#636], https://github.com/admin-shell-io/aas-specs-metamodel/issues/637[#637], https://github.com/admin-shell-io/aas-specs-metamodel/issues/638[#638] )
 * NEW: add to xref:index.adoc#spec-versioning[Versioning] that bugfix releases are not no necessarily backward compatible
+* REMOVED: AdministrativeInformation: remove former Note 2
+
 
 Minor Bugfixes:
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -72,7 +72,7 @@ Minor Changes:
 * ADDED: Handling of operations in Submodel with kind=Instance are handled identical to operation in Submodel Templates (Submodel with kind=Template) (https://github.com/admin-shell-io/aas-specs-metamodel/issues/462[#462])
 * CHANGED: update bibliography
 * CHANGED: editorial changes (including https://github.com/admin-shell-io/aas-specs-metamodel/issues/600[#600], https://github.com/admin-shell-io/aas-specs-metamodel/issues/636[#636], https://github.com/admin-shell-io/aas-specs-metamodel/issues/637[#637], https://github.com/admin-shell-io/aas-specs-metamodel/issues/638[#638] )
-* NEW: add to xref:./shared/versioning.adoc[Versioning] that bugfix releases are not no necessarily backward compatible
+* NEW: add to xref:index.adoc#spec-versioning[Versioning] that bugfix releases are not no necessarily backward compatible
 
 Minor Bugfixes:
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/index.adoc
@@ -46,7 +46,7 @@ https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 In
 
 SPDX-License-Identifier: CC-BY-4.0
 
-DATE TO BE ADDED
+June 2026
 
 == How to Get in Contact
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/mappings/encodings/valueonly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/mappings/encodings/valueonly.adoc
@@ -75,7 +75,7 @@ ${Blob/value}.
 The resulting ValueOnly object is indistinguishable whether it contains File or Blob attributes.
 Therefore, the receiver needs to take the type of the target resource into account.
 Since the receiver knows in advance if a File or a Blob SubmodelElement shall be manipulated, it can parse the transferred Value-Only object accordingly as a File or Blob object.
-For Blobs the value attribute is optional (in this case a Blob can be distinguished from a File).
+
 
 ** xref:spec-metamodel/submodel-elements.adoc#SubmodelElementCollection[SubmodelElementCollection] is serialized as named JSON object with ${SubmodelElementCollection/idShort} as the name of the containing JSON property.
 The elements contained within the struct, i.e. the elements in SubmodelElementCollection/value, are serialized according to their respective type with ${SubmodelElement/idShort} as the name of the containing JSON property.

--- a/documentation/IDTA-01001/modules/ROOT/pages/shared/versioning.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/shared/versioning.adoc
@@ -10,6 +10,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ////
 
 
+[[spec-versioning]]
 === Versioning
 
 This specification is versioned using https://semver.org/spec/v2.0.0.html[Semantic Versioning 2.0.0] (semver) and follows the semver specification xref:bibliography.adoc#bib36[[36\]] 

--- a/documentation/IDTA-01001/modules/ROOT/pages/shared/versioning.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/shared/versioning.adoc
@@ -12,5 +12,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 === Versioning
 
-This specification is versioned using https://semver.org/spec/v2.0.0.html[Semantic Versioning 2.0.0] (semver) and follows the semver specification xref:bibliography.adoc#bib36[[36\]].
+This specification is versioned using https://semver.org/spec/v2.0.0.html[Semantic Versioning 2.0.0] (semver) and follows the semver specification xref:bibliography.adoc#bib36[[36\]] 
+with the following deviations:
+
+* patch releases are bugfix releases and are not necessarily backward compatible. They shall be used.
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
@@ -96,8 +96,8 @@ V1.0 < V1.1 < V2.0
 The date attribute <<createdAt>> is bound to the identity of the object itself, not to its individual version states. 
 This means that while an object's <<version>> or <<revision>> will increment over time, its _createdAt_ timestamp remains fixed to the moment the object was first created.
 
-The date attribute <<updatedAt>>, however, tracks when modifications occur. 
-Because the version and revision increment as the object is updated over time, 
+The date attribute <<updatedAt>>, however, tracks when relevant modifications occur. 
+Because the version and revision increment if there are relevant updates to the object over time, 
 a higher version number mathematically implies a later _updatedAt_ timestamp than that of its previous version states. 
 For example, the _updatedAt_ timestamp of V2.0 will be later than the _updatedAt_ timestamp of V1.1.
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
@@ -43,7 +43,7 @@ Data specifications are defined in IDTA-01003 sub-series.
 
 If an AAS contains two different Submodels with the same semanticId 
 (xref:spec-metamodel/common.adoc#semanticId[Submodel/semanticId])  these two submodels shall have different IDs (xref:spec-metamodel/common.adoc#Identifiable[Submodel/id]) 
-and differ in either their 
+and differ in their 
 
 a) <<version>> (xref:spec-metamodel/common.adoc#version[Submodel/administration/version]) (xref:spec-metamodel/common.adoc#revision[revision] is ignored) 
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
@@ -44,10 +44,20 @@ Data specifications are defined in IDTA-01003 sub-series.
 If an AAS contains two different Submodels with the same semanticId 
 (xref:spec-metamodel/common.adoc#semanticId[Submodel/semanticId])  these two submodels shall have different IDs (xref:spec-metamodel/common.adoc#Identifiable[Submodel/id]) 
 and differ in either their 
+
 a) <<version>> (xref:spec-metamodel/common.adoc#version[Submodel/administration/version]) (xref:spec-metamodel/common.adoc#revision[revision] is ignored) 
-or b) their <<creator>> (xref:spec-metamodel/common.adoc#creator[Submodel/administration/creator]). 
+
+or 
+
+b) their <<createdAt>> or <<updatedAt>> date
+
+or
+
+C) their <<creator>> (xref:spec-metamodel/common.adoc#creator[Submodel/administration/creator]). 
+
 With a) both submodels shall have version information. 
-With b) both submodels shall have a <<creator>>.
+With b) both submodels shall have date information.
+With c) both submodels shall have a <<creator>>.
 
 ====
 Note 1: typically, some of the administrative information like the version number might be part of the identification (xref:spec-metamodel/common.adoc#Identifiable[Submodel/id]). 

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
@@ -74,6 +74,32 @@ In this case there is no way for the data consumer to formally see whether two S
 Note 4: if a template ID (xref:spec-metamodel/common.adoc#templateId[Submodel/administration/templateId]) of one of the standardized Submodel Templates of the IDTA is used to guide the creation of a Submodel then there is also a semantic ID defined for the Submodel.
 ====
 
+To ensure reliable sorting and enable logical comparisons, the <<version>> and <<revision>> attributes are stored as numerical integer types rather than as text strings. 
+This design prevents common sorting errors (e.g., a text-based sort incorrectly placing "V1.10" before "V1.2") and allows the system to mathematically determine which release is newer.
+
+For display purposes, these numbers are typically concatenated into a human-readable string, such as V<version>.<revision>.
+
+This numerical system creates a clear and logical order of precedence, where a higher version or revision number always indicates a later release:
+
+V1.0 < V1.1 < V2.0
+
+The date attribute <<createdAt>> is bound to the identity of the object itself, not to its individual version states. 
+This means that while an object's <<version>> or <<revision>> will increment over time, its _createdAt_ timestamp remains fixed to the moment the object was first created.
+
+The date attribute <<updatedAt>>, however, tracks when modifications occur. 
+Because the version and revision increment as the object is updated over time, 
+a higher version number mathematically implies a later _updatedAt_ timestamp than that of its previous version states. 
+For example, the _updatedAt_ timestamp of V2.0 will be later than the _updatedAt_ timestamp of V1.1.
+
+Finally, for any given state of the object, a fundamental rule applies to these timestamps: the <<updatedAt>> timestamp is always greater than or equal to the <<createdAt>> timestamp, 
+meaning an update can never occur before the initial creation of the object.
+
+====
+Note 5: It is important to clarify that not every change to an object's data will necessarily trigger a new release (update of <<version>> or <<revision>> attributes) or an update to the <<updatedAt>> timestamp. 
+The <<version>>, <<revision>>, <<createdAt>>, and <<updatedAt>> attributes should be treated as business values, not technical system values. 
+Their purpose is to mark significant, business-relevant milestones in an object's lifecycle.
+For more dynamic or transient data—such as real-time calculations or temporary status flags—incrementing the version for every fluctuation would be impractical and would not make sense from a business logic perspective.
+====
 
 [.table-with-appendix-table]
 [cols="25%,40%,25%,10%"]

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
@@ -39,7 +39,7 @@ For more information on the concept of subject as used to describe the <<creator
 The assumption is that every subject has a unique identifier.
 
 xref:spec-metamodel/common.adoc#AdministrativeInformation[AdministrativeInformation] allows the usage of templates (xref:spec-metamodel/common.adoc#HasDataSpecification[HasDataSpecification]).
-Data specifications are defined in separate documents.
+Data specifications are defined in IDTA-01003 sub-series.
 
 If an AAS contains two different Submodels with the same semanticId 
 (xref:spec-metamodel/common.adoc#semanticId[Submodel/semanticId])  these two submodels shall have different IDs (xref:spec-metamodel/common.adoc#Identifiable[Submodel/id]) 

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/common.adoc
@@ -72,16 +72,17 @@ semanticId but different versions.
 ====
 
 
+
 If an AAS contains two different Submodels guided by the same Submodel Template (SMT), i.e. have the same templateId value (Submodel/administration/templateId), then the two submodels shall have different IDs (xref:spec-metamodel/common.adoc#Identifiable[Submodel/id]). 
 In this case both Submodels shall have a templateId assigned to them (xref:spec-metamodel/common.adoc#templateId[Submodel/administration/templateId]).
 
 ====
-Note 3: in some cases there is neither a semanticId (xref:spec-metamodel/common.adoc#semanticId[Submodel/semanticId]) nor a template ID (xref:spec-metamodel/common.adoc#templateId[Submodel/administration/templateId]) defined for the Submodel. 
+Note 2: in some cases there is neither a semanticId (xref:spec-metamodel/common.adoc#semanticId[Submodel/semanticId]) nor a template ID (xref:spec-metamodel/common.adoc#templateId[Submodel/administration/templateId]) defined for the Submodel. 
 In this case there is no way for the data consumer to formally see whether two Submodels are providing the same semantic information.
 ====
 
 ====
-Note 4: if a template ID (xref:spec-metamodel/common.adoc#templateId[Submodel/administration/templateId]) of one of the standardized Submodel Templates of the IDTA is used to guide the creation of a Submodel then there is also a semantic ID defined for the Submodel.
+Note 3: if a template ID (xref:spec-metamodel/common.adoc#templateId[Submodel/administration/templateId]) of one of the standardized Submodel Templates of the IDTA is used to guide the creation of a Submodel then there is also a semantic ID defined for the Submodel.
 ====
 
 To ensure reliable sorting and enable logical comparisons, the <<version>> and <<revision>> attributes are stored as numerical integer types rather than as text strings. 
@@ -105,7 +106,7 @@ Finally, for any given state of the object, a fundamental rule applies to these 
 meaning an update can never occur before the initial creation of the object.
 
 ====
-Note 5: It is important to clarify that not every change to an object's data will necessarily trigger a new release (update of <<version>> or <<revision>> attributes) or an update to the <<updatedAt>> timestamp. 
+Note 4: It is important to clarify that not every change to an object's data will necessarily trigger a new release (update of <<version>> or <<revision>> attributes) or an update to the <<updatedAt>> timestamp. 
 The <<version>>, <<revision>>, <<createdAt>>, and <<updatedAt>> attributes should be treated as business values, not technical system values. 
 Their purpose is to mark significant, business-relevant milestones in an object's lifecycle.
 For more dynamic or transient data—such as real-time calculations or temporary status flags—incrementing the version for every fluctuation would be impractical and would not make sense from a business logic perspective.

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/designators.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/designators.adoc
@@ -22,3 +22,9 @@ They are abstract, i.e. there is no object instance of such classes.
 The concept of referencing and how a reference is represented in the UML diagrams and the tables is explained in  xref:spec-metamodel/referencing.adoc[] and Annex xref:ROOT:annex/uml.adoc[].
 
 Constraints that are no invariants of classes are specified in  xref:spec-metamodel/constraints.adoc[].
+
+A minimum recursion depth of 32 for xref:spec-metamodel/referencing.adoc#AasContainerSubmodelElements[Container-Elements] should be supported.
+
+====
+Note: This means for certification a maximum of 32 recursion test cases should be tested.
+====


### PR DESCRIPTION
* Value-Only: remove sentence "For Blobs the value attribute is optional (in this case a Blob can be distinguished from a File)." since value also optional for File
* editorial including fix figure in dpp Annex
* semver: bugfix versions are not necessarily backward compatible
* add explanatory text for versioning and date handling in AdministrativeInformation
* #333 fix recursion depth information (contained in changelog but not in text)
* index.adoc: add date "June 2026"