### PR TITLE
#450 invalidate experimental SME Range

### DIFF
--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/dpp.adoc
@@ -282,6 +282,12 @@ Event (abstract) a| Events are not supported in EN 18223
 |--| `\https://admin-shell.io/aas/3/2/Range`
 
 Range a| can be realized with a EN 18223 DataElementCollection
+
+[Note]
+====
+xref:spec-metamodel/submodel-elements.adoc#Range[Range] was experimental, is invalidated
+====
+
 |--| `\https://admin-shell.io/aas/3/2/ReferenceElement` 
 
 ReferenceElement a| could be realized with a EN 18223 DataElementCollection and MultiValuedDataElement, however, it is not foreseen in EN 18223 that elements are referenced

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/overview-constraints.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/overview-constraints.adoc
@@ -45,6 +45,11 @@ For handling of constraints see xref:annex/handling-constraints.adoc[].
 
 {aasd109}
 
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
+
 {aasd114}
 
 {aasd115}

--- a/documentation/IDTA-01001/modules/ROOT/pages/annex/uml-templates.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/annex/uml-templates.adoc
@@ -28,7 +28,7 @@ For capitalization of titles, rules according to https://capitalizemytitle.com/ 
 :table-caption: Template
 [cols="25%,40%,25%,10%"]
 |===
-h|Class: 3+e|<Class Name> ["\<<abstract>>"] ["\<<Experimental>>"] ["\<<Deprecated>>"] ["\<<Template>>"]
+h|Class: 3+e|<Class Name> ["\<<abstract>>"] ["\<<Experimental>>" | \<<Invalidated>>" ] ["\<<Deprecated>>"] ["\<<Template>>"]
 h|Explanation: 3+a|<Explanatory text>
 h|Inherits from: 3+|{<Class Name> ";" }+ \| "-"
 h|ID: 3+| `<metamodel element ID>`
@@ -47,6 +47,7 @@ The following stereotypes can be used:
 
 * \<<abstract>>: Class cannot be instantiated but serves as superclass for inheriting classes
 * \<<Experimental>>: Class is experimental, i.e. usage is only recommended for experimental purposes because non-backward compatible changes may occur in future versions
+* \<<Invalidated>>: Class was experimental but it was decided to not support it in future versions
 * \<<Deprecated>>: Class is deprecated, i.e. it is recommended to not use the element any longer; it will be removed in a next major version of the model
 * \<<Template>>: Class is a template only, i.e. class is not instantiated but used for additional specification purposes (for details see parts 3 of document series)
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -44,7 +44,12 @@ They had separate sections and tables documenting the changes.
 Major Changes:
 
 * NEW: add fingerprint to SubmodelElement File  (link:https://github.com/admin-shell-io/aas-specs-metamodel/issues/668[#668])
+* INVALIDATED: experimental SubmodelElement Range will not be supported in future, in alignment with IEC 63278-2 (link:https://github.com/admin-shell-io/aas-specs-metamodel/issues/450[#450])
 * DELETED: Annex "General Topics", "Usage Metamodel" and "AAS Concepts" (https://github.com/admin-shell-io/aas-specs-metamodel/issues/596)[#596]), these parts are now part of a link:https://industrialdigitaltwin.io/aas-guides-antora/AAS_Concepts/1.0/imprint.html[separate guide]
+
+Minor Changes:
+
+* Annex xref:annex/uml-template.adoc[UML Template]: add new stereotype \<<Invalidated>>:
 
 .Changes in Metamodel
 [cols="5%,42%,48%",options="header",]
@@ -52,6 +57,7 @@ Major Changes:
 h|Nc h|V3.3 Change w.r.t. V3.2 h|Comment
 
 | {empty} | xref:spec-metamodel/submodel-elements.adoc#File[File] a| add new attribute fingerprint to SubmodelElement "File"
+| {empty} | xref:spec-metamodel/submodel-elements.adoc#Range[Range] a| Range was experimental, will not be supported in future (invalidated)
 |===
 
 .New Elements in Metamodel

--- a/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/changelog.adoc
@@ -49,7 +49,7 @@ Major Changes:
 
 Minor Changes:
 
-* Annex xref:annex/uml-template.adoc[UML Template]: add new stereotype \<<Invalidated>>:
+* Annex xref:annex/uml-templates.adoc[UML Template]: add new stereotype \<<Invalidated>>:
 
 .Changes in Metamodel
 [cols="5%,42%,48%",options="header",]

--- a/documentation/IDTA-01001/modules/ROOT/pages/mappings/encodings/valueonly.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/mappings/encodings/valueonly.adoc
@@ -66,6 +66,11 @@ The first is named "min".
 The second is named "max".
 Their corresponding values are ${Range/min} and ${Range/max}.
 
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
+
 ** xref:spec-metamodel/submodel-elements.adoc#File[File]  and xref:spec-metamodel/submodel-elements.adoc#Blob[Blob]  are serialized as named JSON objects with ${File/idShort} or ${Blob/idShort} as the name of the containing JSON property.
 The JSON object contains two JSON properties.
 The first refers to the content type named ${File/contentType} resp.
@@ -120,6 +125,11 @@ The following rules shall be adhered to when serializing a single SubmodelElemen
 ** _Property_ is serialized as ${Property/value} where ${Property/value} is serialized as described above.
 ** _MultiLanguageProperty_ is serialized as JSON object. The JSON object is serialized as described above.
 ** _Range_ is serialized as JSON object. The JSON object is serialized as described above.
+
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
 ** _File_ and _Blob_ are serialized as JSON objects. The JSON object is serialized as described above.
 ** _ReferenceElement_ is serialized as ${ReferenceElement/value} where ${ReferenceElement/value} is is serialized as described above.
 ** _RelationshipElement_ is serialized as JSON object. The JSON object is serialized as described above.
@@ -411,6 +421,11 @@ For a _MultiLanguageProperty_ the Value-Only payload is minimized to the followi
 
 ----
 ===== Range
+
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
 
 For a _Range_ named "TorqueRange", the Value-Only payload is minimized to the following:
 

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/referencing.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/referencing.adoc
@@ -248,6 +248,11 @@ a|Property
 .2+e|Range | `\https://admin-shell.io/aas/3/2/KeyTypes/Range`
 a|Range with min and max
 
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
+
 .2+e|Referable | `\https://admin-shell.io/aas/3/2/KeyTypes/Referable`
 a|
 ====
@@ -370,6 +375,10 @@ a|Property
 .2+e|Range | `\https://admin-shell.io/aas/3/2/AasReferableNonIdentifiables/Range`
 a|Range with min and max
 
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
 
 .2+e|ReferenceElement | `\https://admin-shell.io/aas/3/2/AasReferableNonIdentifiables/ReferenceElement`
 a|Reference
@@ -466,7 +475,10 @@ a|Property
 .2+e|Range | `\https://admin-shell.io/aas/3/2/AasNonContainerSubmodelElements/Range`
 a|Range with min and max
 
-
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
 
 .2+e|ReferenceElement | `\https://admin-shell.io/aas/3/2/AasNonContainerSubmodelElements/ReferenceElement`
 a|Reference
@@ -610,6 +622,11 @@ a|Property
 .2+e|Range | `\https://admin-shell.io/aas/3/2/AasReferables/Range`
 a|Range with min and max
 
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
+
 .2+e|Referable | `\https://admin-shell.io/aas/3/2/AasReferables/Referable`
 a|
 ====
@@ -723,6 +740,10 @@ a|Property
 .2+e|Range | `\https://admin-shell.io/aas/3/2/FragmentKeys/Range`
 a|Range with min and max
 
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
 
 .2+e|ReferenceElement | `\https://admin-shell.io/aas/3/2/FragmentKeys/ReferenceElement`
 a|Reference

--- a/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/submodel-elements.adoc
+++ b/documentation/IDTA-01001/modules/ROOT/pages/spec-metamodel/submodel-elements.adoc
@@ -696,7 +696,7 @@ include::partial$diagrams/41-range.puml[]
 [.table-with-appendix-table]
 [cols="25%,40%,25%,10%"]
 |===
-h|Class: 3+e|[[Range]]Range \<<Experimental>>
+h|Class: 3+e|[[Range]]Range \<<Invalidated>>
 h|Explanation: 3+a|A range data element is a data element that defines a range with min and max.
 h|Inherits from: 3+|xref:DataElement[DataElement]
 h|ID: 3+| `\https://admin-shell.io/aas/3/2/Range`
@@ -873,6 +873,11 @@ The numbering starts with Zero (0).
 {aasd108}
 
 {aasd109}
+
+[Note]
+====
+The formerly experimental SubmodelElement xref:spec-metamodel/submodel-elements.adoc#Range[Range] is invalidated, i.e. will not be supported in future.
+====
 
 {aasd138}
 

--- a/documentation/IDTA-01001/modules/ROOT/partials/diagrams/classes/range.puml
+++ b/documentation/IDTA-01001/modules/ROOT/partials/diagrams/classes/range.puml
@@ -1,5 +1,5 @@
 @startuml
-class Range<DataElement> <<Experimental>> {
+class Range<DataElement> <<Invalidated>> {
   +valueType: DataTypeDefXsd
   +min: ValueDataType[0..1]
   +max: ValueDataType[0..1]


### PR DESCRIPTION
closes #450 
invalidate SME Range

* new stereotype invalidated, otherwise deprecated for "normal" elements and experimental elements not visible
* add notes at places Range is used